### PR TITLE
API change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,17 +10,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
 - Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
+- Renamed `from_regular` for `like`.
 
 ## [0.1.2] - 2021-08-1
 ### Added
-- Pooling modules: `MaxPool1d`, `AvgPool3d`, `MaxPool3d`, `AdaptiveAvgPool3d`, `AdaptiveMaxPool3d`
+- Pooling modules: `MaxPool1d`, `AvgPool3d`, `MaxPool3d`, `AdaptiveAvgPool3d`, `AdaptiveMaxPool3d`.
 
 
 ## [0.1.1] - 2021-08-10
 ### Added
-- Updated README
+- Updated README.
 
 
 ## [0.1.0] - 2021-08-10
 ### Added
-- Initial publicly available implementation of the library
+- Initial publicly available implementation of the library.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
+## Changed
+- Naming to match torch.nn. This lets the continual modules be used as drop-in replacements for torch.nn modules.
 
 ## [0.1.2] - 2021-08-1
 ### Added
-- Pooling modules: MaxPoolCo1d, AvgPoolCo3d, MaxPoolCo3d, AdaptiveAvgPoolCo3d, AdaptiveMaxPoolCo3d
+- Pooling modules: nn.MaxPool1d, nn.AvgPool3d, nn.MaxPool3d, nn.AdaptiveAvgPool3d, nn.AdaptiveMaxPool3d
 
 
 ## [0.1.1] - 2021-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Changed
 - Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
 - Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
-- Renamed `from_regular` for `like`.
+- Renamed `from_regular` to `build_from`.
+- Renamed `continual` to `unsqueezed`.
+
+## Added
+- `Sequential`
+- `continual` conversion function
+- `register` function for 3rd party modules to register their conversion
+- Additional tests
 
 ## [0.1.2] - 2021-08-1
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Renamed `continual` to `unsqueezed`.
 
 ## Added
-- `Sequential`
+- `Sequential` wrapper for sequential application of modules
+- `Parallel` wrapper for parallel application and aggregation of inputs
+- `Residual` wrapper for adding a unity residual to a module
 - `continual` conversion function
 - `register` function for 3rd party modules to register their conversion
 - Additional tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.2.0]
 ## Changed
 - Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
 - Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
 
 ## [0.1.2] - 2021-08-1
 ### Added
-- Pooling modules: nn.MaxPool1d, nn.AvgPool3d, nn.MaxPool3d, nn.AdaptiveAvgPool3d, nn.AdaptiveMaxPool3d
+- Pooling modules: `MaxPool1d`, `AvgPool3d`, `MaxPool3d`, `AdaptiveAvgPool3d`, `AdaptiveMaxPool3d`
 
 
 ## [0.1.1] - 2021-08-10

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ## Changed
-- Naming to match torch.nn. This lets the continual modules be used as drop-in replacements for torch.nn modules.
+- Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
+- Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
 
 ## [0.1.2] - 2021-08-1
 ### Added

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ For more information, we refer to the [seminal paper on Continual Convolutions](
 ## Forward modes
 The library components feature three distinct forward modes, which are handy for different situations.
 
-### `forward`
+### `forward_step`
 Performs a forward computation for a single frame and continual states are updated accordingly. This is the mode to use for continual inference.
 
 ```
@@ -158,7 +158,7 @@ O+S O+S O+S O+S   (O: output, S: updated internal state)
  I   I   I   I    (I: input frame)
 ```
 
-### `forward_regular`
+### `forward_steps`
 Performs a layer-wise forward computation using the continual module.
 The computation is performed frame-by-frame and continual states are updated accordingly.
 The output-input mapping the exact same as that of a regular module.
@@ -174,7 +174,7 @@ This mode is handy for initialising the network on a whole clip (multipleframes)
  P   I   I   I   P    (I: input frame, P: padding)
 ```
 
-### `forward_regular_unrolled`
+### `forward`
 Performs a full forward computation exactly as the regular layer would.
 This method is handy for effient training on clip-based data.
 

--- a/README.md
+++ b/README.md
@@ -25,10 +25,34 @@ Building blocks for Continual Inference Networks in PyTorch
 pip install continual-inference
 ```
 
+## Usage
+```python3
+import torch
+from torch import nn
+import continual as co
+                                                           # B, C, T, H, W
+example = torch.normal(mean=torch.zeros(4 * 3 * 3)).reshape((1, 1, 4, 3, 3))
+
+# Acts as a drop-in replacement for torch.nn modules ✅
+co_conv = co.nn.Conv3d(in_channels=1, out_channels=1, kernel_size=(3, 3, 3))
+nn_conv = nn.nn.Conv3d(in_channels=1, out_channels=1, kernel_size=(3, 3, 3))
+
+co_output = co_conv(example) # Same exact computation
+nn_output = nn_conv(example) # Same exact computation
+assert torch.allequals(co_output, nn_output)
+
+# But can also perform online inference efficiently 🎉
+firsts = co_conv.forward_steps(example[:,:,:3])
+last = co_conv.forward_step(example[:,:,3])
+
+assert nn_output[:,:,:] == firsts[:,:,co_conv.delay:]
+assert nn_output[:,:,co_conv.delay] == last
+```
+
 ## Continual Inference Networks (CINs)
 Continual Inference Networks are a type of neural network, which operate on a continual input stream of data and infer a new prediction for each new time-step.
 
-All networks and network-modules, that do not utilise temporal information can be used for an Online Inference Network (e.g. `Conv1d` and `Conv2d` on spatial data such as an image). 
+All networks and network-modules, that do not utilise temporal information can be used for an Online Inference Network (e.g. `nn.Conv1d` and `nn.Conv2d` on spatial data such as an image). 
 Moreover, recurrent modules (e.g. `LSTM` and `GRU`), that summarize past events in an internal state are also useable in CINs.
 
 __CIN__:
@@ -42,7 +66,7 @@ Conv2D  Conv2D  Conv2D   (spatial 2D conv)
   I       I       I      (input frame)
 ```
 
-However, modules that operate on temporal data with the assumption that the more temporal context is available than the current frame (e.g. the spatio-temporal `Conv3d` used by many SotA video recognition models) cannot be directly applied.
+However, modules that operate on temporal data with the assumption that the more temporal context is available than the current frame (e.g. the spatio-temporal `nn.Conv3d` used by many SotA video recognition models) cannot be directly applied.
 
 __Not CIN__:
 ```
@@ -72,30 +96,32 @@ This repository contains online inference-friendly versions of common network bu
 
 <!-- TODO: Replace with link to docs once they are set up -->
 - (Temporal) convolutions:
-    - `ConvCo1d`
-    - `ConvCo2d`
-    - `ConvCo3d`
+    - `co.Conv1d`
+    - `co.Conv2d`
+    - `co.Conv3d`
 
 - (Temporal) batch normalisation:
-    - `BatchNormCo2d`
+    - `co.BatchNorm2d`
 
 - (Temporal) pooling:
-    - `AvgPoolCo1d`
-    - `AvgPoolCo2d`
-    - `AvgPoolCo3d`
-    - `MaxPoolCo1d`
-    - `MaxPoolCo2d`
-    - `MaxPoolCo3d`
-    - `AdaptiveAvgPoolCo1d`
-    - `AdaptiveAvgPoolCo2d`
-    - `AdaptiveAvgPoolCo3d`
-    - `AdaptiveMaxPoolCo1d`
-    - `AdaptiveMaxPoolCo2d`
-    - `AdaptiveMaxPoolCo3d`
+    - `co.AvgPool1d`
+    - `co.AvgPool2d`
+    - `co.AvgPool3d`
+    - `co.MaxPool1d`
+    - `co.MaxPool2d`
+    - `co.MaxPool3d`
+    - `co.AdaptiveAvgPool1d`
+    - `co.AdaptiveAvgPool2d`
+    - `co.AdaptiveAvgPool3d`
+    - `co.AdaptiveMaxPool1d`
+    - `co.AdaptiveMaxPool2d`
+    - `co.AdaptiveMaxPool3d`
 
 - Other
-    - `Delay` - pure delay module
-    - `Continual` - functional wrapper for non-continual modules
+    <!-- - `co.Sequential` -->
+    - `co.Delay` - pure delay module
+    <!-- - `co.Residual` - residual connection, which automatically adds delay if needed -->
+    - `co.continual` - functional wrapper for non-continual modules
 
 ### Continual Convolutions
 Continual Convolutions can lead to major improvements in computational efficiency when online / frame-by-frame predictions are required.

--- a/README.md
+++ b/README.md
@@ -119,10 +119,13 @@ This repository contains online inference-friendly versions of common network bu
     - `co.AdaptiveMaxPool3d`
 
 - Other
-    - `co.Sequential`
+    - `co.Sequential` - sequential wrapper for modules
+    - `co.Parallel` - parallel wrapper for modules
+    - `co.Residual` - residual wrapper for modules
     - `co.Delay` - pure delay module
     <!-- - `co.Residual` - residual connection, which automatically adds delay if needed -->
-    - `co.continual` - functional wrapper for non-continual modules
+    - `co.unsqueezed` - functional wrapper for non-continual modules
+    - `co.continual` - conversion function from non-continual modules to continual moduls
 
 ### Continual Convolutions
 Continual Convolutions can lead to major improvements in computational efficiency when online / frame-by-frame predictions are required.

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,4 @@
+coverage:
+  status:
+    project: on
+    patch: off

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -14,4 +14,4 @@ from .pooling import (  # noqa: F401
     MaxPool2d,
     MaxPool3d,
 )
-from .utils import continual, TensorPlaceholder, Zero  # noqa: F401
+from .utils import TensorPlaceholder, Zero, continual  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -1,5 +1,5 @@
 from .batchnorm import BatchNorm2d  # noqa: F401
-from .container import Sequential  # noqa: F401
+from .container import Parallel, Residual, Sequential  # noqa: F401
 from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
 from .convert import continual  # noqa: F401
 from .delay import Delay  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -1,9 +1,9 @@
 from .batchnorm import BatchNorm2d  # noqa: F401
 from .container import Sequential  # noqa: F401
 from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
+from .convert import continual  # noqa: F401
 from .delay import Delay  # noqa: F401
 from .interface import CoModule, TensorPlaceholder  # noqa: F401
-from .utils import Zero  # noqa: F401
 from .pooling import (  # noqa: F401
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,
@@ -16,5 +16,5 @@ from .pooling import (  # noqa: F401
     MaxPool2d,
     MaxPool3d,
 )
-from .convert import continual  # noqa: F401
 from .ptflops import register_ptflops  # noqa: F401
+from .utils import Zero  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -1,17 +1,17 @@
-from .batchnorm import BatchNormCo2d  # noqa: F401
-from .conv import ConvCo1d, ConvCo2d, ConvCo3d  # noqa: F401
+from .batchnorm import BatchNorm2d  # noqa: F401
+from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
 from .delay import Delay  # noqa: F401
 from .interface import _CoModule  # noqa: F401
 from .pooling import (  # noqa: F401
-    AdaptiveAvgPoolCo2d,
-    AdaptiveAvgPoolCo3d,
-    AdaptiveMaxPoolCo2d,
-    AdaptiveMaxPoolCo3d,
-    AvgPoolCo1d,
-    AvgPoolCo2d,
-    AvgPoolCo3d,
-    MaxPoolCo1d,
-    MaxPoolCo2d,
-    MaxPoolCo3d,
+    AdaptiveAvgPool2d,
+    AdaptiveAvgPool3d,
+    AdaptiveMaxPool2d,
+    AdaptiveMaxPool3d,
+    AvgPool1d,
+    AvgPool2d,
+    AvgPool3d,
+    MaxPool1d,
+    MaxPool2d,
+    MaxPool3d,
 )
 from .utils import continual, TensorPlaceholder, Zero  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -1,7 +1,9 @@
 from .batchnorm import BatchNorm2d  # noqa: F401
+from .container import Sequential  # noqa: F401
 from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
 from .delay import Delay  # noqa: F401
-from .interface import _CoModule  # noqa: F401
+from .interface import CoModule, TensorPlaceholder  # noqa: F401
+from .utils import Zero  # noqa: F401
 from .pooling import (  # noqa: F401
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,
@@ -14,4 +16,5 @@ from .pooling import (  # noqa: F401
     MaxPool2d,
     MaxPool3d,
 )
-from .utils import TensorPlaceholder, Zero, continual  # noqa: F401
+from .convert import continual  # noqa: F401
+from .ptflops import register_ptflops  # noqa: F401

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -66,3 +66,6 @@ class BatchNorm2d(_BatchNorm, CoModule):
     @property
     def delay(self) -> int:
         return 0
+
+    def clean_state(self):
+        ...

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -1,3 +1,4 @@
+import torch
 from torch import Tensor
 from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
@@ -49,7 +50,7 @@ class BatchNorm2d(_BatchNorm, CoModule):
 
     @staticmethod
     def build_from(module: nn.BatchNorm2d):
-        return BatchNorm2d(
+        comodule = BatchNorm2d(
             num_features=module.num_features,
             eps=module.eps,
             momentum=module.momentum,
@@ -57,6 +58,11 @@ class BatchNorm2d(_BatchNorm, CoModule):
             track_running_stats=module.track_running_stats,
             window_size=1,
         )
+
+        with torch.no_grad():
+            comodule.load_state_dict(module.state_dict())
+
+        return comodule
 
     @property
     def delay(self) -> int:

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -9,7 +9,7 @@ def normalise_momentum(num_frames: int, base_mom=0.1):
     return 2 / (num_frames * (2 / base_mom - 1) + 1)
 
 
-class BatchNormCo2d(_BatchNorm, _CoModule):
+class BatchNorm2d(_BatchNorm, _CoModule):
     def __init__(
         self,
         num_features,
@@ -19,7 +19,7 @@ class BatchNormCo2d(_BatchNorm, _CoModule):
         track_running_stats=True,
         window_size=1,
     ):
-        super(BatchNormCo2d, self).__init__(
+        super(BatchNorm2d, self).__init__(
             num_features, eps, momentum, affine, track_running_stats
         )
         # Normalise momentum w.r.t. the expected clip size

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -1,6 +1,5 @@
 import torch
-from torch import Tensor
-from torch import nn
+from torch import Tensor, nn
 from torch.nn.modules.batchnorm import _BatchNorm
 
 from .interface import CoModule

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -34,14 +34,14 @@ class BatchNorm2d(_BatchNorm, _CoModule):
                 "expected 2D, 3D, or 4D input (got {}D input)".format(input.dim())
             )
 
-    def forward(self, input: Tensor) -> Tensor:
+    def forward_step(self, input: Tensor) -> Tensor:
         output = _BatchNorm.forward(self, input)
         return output
 
-    def forward_regular(self, input: Tensor) -> Tensor:
-        return self.forward_regular_unrolled(input)
+    def forward_steps(self, input: Tensor) -> Tensor:
+        return self.forward(input)
 
-    def forward_regular_unrolled(self, input: Tensor) -> Tensor:
+    def forward(self, input: Tensor) -> Tensor:
         with temporary_parameter(self, "momentum", self.unnormalised_momentum):
             output = _BatchNorm.forward(self, input)
         return output

--- a/continual/batchnorm.py
+++ b/continual/batchnorm.py
@@ -1,7 +1,8 @@
 from torch import Tensor
+from torch import nn
 from torch.nn.modules.batchnorm import _BatchNorm
 
-from .interface import _CoModule
+from .interface import CoModule
 from .utils import temporary_parameter
 
 
@@ -9,7 +10,7 @@ def normalise_momentum(num_frames: int, base_mom=0.1):
     return 2 / (num_frames * (2 / base_mom - 1) + 1)
 
 
-class BatchNorm2d(_BatchNorm, _CoModule):
+class BatchNorm2d(_BatchNorm, CoModule):
     def __init__(
         self,
         num_features,
@@ -45,6 +46,17 @@ class BatchNorm2d(_BatchNorm, _CoModule):
         with temporary_parameter(self, "momentum", self.unnormalised_momentum):
             output = _BatchNorm.forward(self, input)
         return output
+
+    @staticmethod
+    def build_from(module: nn.BatchNorm2d):
+        return BatchNorm2d(
+            num_features=module.num_features,
+            eps=module.eps,
+            momentum=module.momentum,
+            affine=module.affine,
+            track_running_stats=module.track_running_stats,
+            window_size=1,
+        )
 
     @property
     def delay(self) -> int:

--- a/continual/container.py
+++ b/continual/container.py
@@ -1,7 +1,9 @@
-from torch import nn
-from .interface import CoModule
-from typing import Optional
 from collections import OrderedDict
+from typing import Optional
+
+from torch import nn
+
+from .interface import CoModule
 
 __all__ = ["Sequential"]
 

--- a/continual/container.py
+++ b/continual/container.py
@@ -1,11 +1,15 @@
 from collections import OrderedDict
-from typing import Optional
+from enum import Enum
+from functools import reduce
+from typing import Callable, Optional, Sequence, Union, overload
 
-from torch import nn
+import torch
+from torch import Tensor, nn
 
-from .interface import CoModule
+from .delay import Delay
+from .interface import CoModule, FillMode
 
-__all__ = ["Sequential"]
+__all__ = ["Sequential", "Parallel", "Residual"]
 
 
 class Sequential(nn.Sequential, CoModule):
@@ -41,3 +45,169 @@ class Sequential(nn.Sequential, CoModule):
         return Sequential(
             OrderedDict([(k, continual(m)) for k, m in module._modules.items()])
         )
+
+    def clean_state(self):
+        for m in self:
+            if hasattr(m, "clean_state"):
+                m.clean_state()
+
+
+class Aggregation(Enum):
+    SUM = "sum"
+    CONCAT = "concat"
+
+
+def parallel_sum(modules: Sequence[Tensor]) -> Tensor:
+    if len(modules) == 0:  # pragma: no cover
+        return torch.tensor([])
+    return reduce(torch.Tensor.add_, modules, torch.zeros_like(modules[0]))
+
+
+def parallel_concat(modules: Sequence[Tensor]) -> Tensor:
+    return torch.cat(modules, dim=1)  # channel dim for inputs of shape (B, C, T, H, W)
+
+
+AggregationFunc = Union[Aggregation, Callable[[Sequence[Tensor]], Tensor]]
+
+
+class Parallel(nn.Sequential, CoModule):
+    """Continual parallel container.
+
+    Args:
+        *args: Either vargs of modules or an OrderedDict.
+        aggregation_fn (AggregationFunc, optional):
+            Function used to aggregate the parallel outputs.
+            Sum or concatenation can be specified by passing Aggregation.SUM or Aggregation.CONCAT respectively.
+            Custom aggregation functions can also be passed.
+            Defaults to Aggregation.SUM.
+        auto_delay (bool, optional):
+            Automatically add delay to modules in order to match the longest delay.
+            Defaults to True.
+
+    """
+
+    @overload
+    def __init__(
+        self,
+        *args: CoModule,
+        aggregation_fn: AggregationFunc = Aggregation.SUM,
+        auto_delay=True,
+    ) -> None:
+        ...  # pragma: no cover
+
+    @overload
+    def __init__(
+        self,
+        arg: "OrderedDict[str, CoModule]",
+        aggregation_fn: AggregationFunc = Aggregation.SUM,
+        auto_delay=True,
+    ) -> None:
+        ...  # pragma: no cover
+
+    def __init__(
+        self,
+        *args,
+        aggregation_fn: AggregationFunc = Aggregation.SUM,
+        auto_delay=True,
+    ):
+        super(Parallel, self).__init__()
+
+        if len(args) == 1 and isinstance(args[0], OrderedDict):
+            modules = [(key, module) for key, module in args[0].items()]
+        else:
+            modules = [(str(idx), module) for idx, module in enumerate(args)]
+
+        if auto_delay:
+            # If there is a delay mismatch, automatically add delay to match the longest
+            max_delay = max([m.delay for _, m in modules])
+            modules = [
+                (
+                    key,
+                    (
+                        Sequential(module, Delay(max_delay - module.delay))
+                        if module.delay < max_delay
+                        else module
+                    ),
+                )
+                for key, module in modules
+            ]
+
+        for key, module in modules:
+            self.add_module(key, module)
+
+        self.aggregation_fn = (
+            aggregation_fn
+            if callable(aggregation_fn)
+            else {
+                Aggregation.SUM: parallel_sum,
+                Aggregation.CONCAT: parallel_concat,
+            }[aggregation_fn]
+        )
+
+        delays = set(m.delay for m in self)
+        assert (
+            len(delays) == 1
+        ), f"Parallel modules should have the same delay, but found delays {delays}."
+        self._delay = delays.pop()
+
+    def forward_step(self, input: Tensor) -> Tensor:
+        return self.aggregation_fn([m.forward_step(input) for m in self])
+
+    def forward_steps(self, input: Tensor) -> Tensor:
+        outs = [self.forward_step(input[:, :, t]) for t in range(input.shape[2])]
+
+        if len(outs) > 0:
+            outs = torch.stack(outs, dim=2)
+        else:
+            outs = torch.tensor([])  # pragma: no cover
+
+        return outs
+
+    def forward(self, input: Tensor) -> Tensor:
+        outs = [m.forward(input) for m in self]
+
+        ts = [x.shape[2] for x in outs]
+        min_t = min(ts)
+        if min_t == max(ts):
+            return self.aggregation_fn(outs)
+
+        # Modules may shrink the output map differently.
+        # If an "even" shrink is detected, attempt to automatically
+        # shrink the longest values to fit as if padding was used.
+        assert all(
+            [(t - min_t) % 2 == 0 for t in ts]
+        ), f"Found incompatible temporal output-shapes {ts}"
+        shrink = [(t - min_t) // 2 for t in ts]
+
+        return self.aggregation_fn(
+            [o[:, :, slice(s, -s or None)] for (s, o) in zip(shrink, outs)]
+        )
+
+    @property
+    def delay(self) -> int:
+        return self._delay
+
+    def clean_state(self):
+        for m in self:
+            if hasattr(m, "clean_state"):
+                m.clean_state()
+
+
+def Residual(module: CoModule, temporal_fill: FillMode = None):
+    return Parallel(
+        OrderedDict(
+            [
+                ("module", module),
+                (
+                    "residual",
+                    Delay(
+                        delay=module.delay,
+                        temporal_fill=temporal_fill
+                        or getattr(module, "temporal_fill", FillMode.REPLICATE.value),
+                    ),
+                ),
+            ]
+        ),
+        aggregation_fn=Aggregation.SUM,
+        auto_delay=False,
+    )

--- a/continual/container.py
+++ b/continual/container.py
@@ -1,0 +1,41 @@
+from torch import nn
+from .interface import CoModule
+from typing import Optional
+from collections import OrderedDict
+
+__all__ = ["Sequential"]
+
+
+class Sequential(nn.Sequential, CoModule):
+    """Continual Sequential module
+
+    This module is a drop-in replacement for `torch.nn.Sequential`
+    which adds the `forward_step`, `forward_steps`, and `like` methods
+    as well as a `delay` property
+    """
+
+    def add_module(self, name: str, module: Optional["nn.Module"]) -> None:
+        CoModule._validate_class(module)
+        nn.Module.add_module(self, name, module)
+
+    def forward_step(self, input):
+        for module in self:
+            input = module.forward_step(input)
+        return input
+
+    def forward_steps(self, input):
+        for module in self:
+            input = module.forward_steps(input)
+        return input
+
+    @property
+    def delay(self):
+        return sum(m.delay for m in self)
+
+    @staticmethod
+    def build_from(module: nn.Sequential) -> "Sequential":
+        from .convert import continual  # import here due to circular import
+
+        return Sequential(
+            OrderedDict([(k, continual(m)) for k, m in module._modules.items()])
+        )

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -46,7 +46,7 @@ class _ConvCoNd(_ConvNd, CoModule):
         groups: int = 1,
         bias: bool = True,
         padding_mode: FillMode = "zeros",
-        temporal_fill: FillMode = "replicate",
+        temporal_fill: FillMode = "zeros",
     ):
         assert issubclass(
             ConvClass, _ConvNd
@@ -285,7 +285,7 @@ class Conv1d(_ConvCoNd):
         groups: int = 1,
         bias: bool = True,
         padding_mode: FillMode = "zeros",
-        temporal_fill: FillMode = "replicate",
+        temporal_fill: FillMode = "zeros",
     ):
         r"""Applies a continual 1D convolution over an input signal composed of several input
         planes.
@@ -345,9 +345,7 @@ class Conv1d(_ConvCoNd):
         )
 
     @staticmethod
-    def build_from(
-        module: nn.Conv1d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv1d":
+    def build_from(module: nn.Conv1d, temporal_fill: FillMode = "zeros") -> "Conv1d":
         dilation = (1, *module.dilation[1:])
         if dilation != module.dilation:
             logger.warning(
@@ -385,7 +383,7 @@ class Conv2d(_ConvCoNd):
         groups: int = 1,
         bias: bool = True,
         padding_mode: FillMode = "zeros",
-        temporal_fill: FillMode = "replicate",
+        temporal_fill: FillMode = "zeros",
     ):
         r"""Applies a continual 2D convolution over an input signal composed of several input
         planes.
@@ -445,9 +443,7 @@ class Conv2d(_ConvCoNd):
         )
 
     @staticmethod
-    def build_from(
-        module: nn.Conv2d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv2d":
+    def build_from(module: nn.Conv2d, temporal_fill: FillMode = "zeros") -> "Conv2d":
         dilation = (1, *module.dilation[1:])
         if dilation != module.dilation:
             logger.warning(
@@ -485,7 +481,7 @@ class Conv3d(_ConvCoNd):
         groups: int = 1,
         bias: bool = True,
         padding_mode: FillMode = "zeros",
-        temporal_fill: FillMode = "replicate",
+        temporal_fill: FillMode = "zeros",
     ):
         r"""Applies a continual 3D convolution over an input signal composed of several input
         planes.
@@ -547,9 +543,7 @@ class Conv3d(_ConvCoNd):
         )
 
     @staticmethod
-    def build_from(
-        module: nn.Conv3d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv3d":
+    def build_from(module: nn.Conv3d, temporal_fill: FillMode = "zeros") -> "Conv3d":
         stride = (1, *module.stride[1:])
         dilation = (1, *module.dilation[1:])
         for shape, name in zip(

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -350,9 +350,7 @@ class Conv1d(_ConvCoNd):
         )
 
     @staticmethod
-    def from_regular(
-        module: nn.Conv1d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv1d":
+    def like(module: nn.Conv1d, temporal_fill: FillMode = "replicate") -> "Conv1d":
         dilation = (1, *module.dilation[1:])
         if dilation != module.dilation:
             warn(
@@ -450,9 +448,7 @@ class Conv2d(_ConvCoNd):
         )
 
     @staticmethod
-    def from_regular(
-        module: nn.Conv2d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv2d":
+    def like(module: nn.Conv2d, temporal_fill: FillMode = "replicate") -> "Conv2d":
         dilation = (1, *module.dilation[1:])
         if dilation != module.dilation:
             warn(
@@ -552,9 +548,7 @@ class Conv3d(_ConvCoNd):
         )
 
     @staticmethod
-    def from_regular(
-        module: nn.Conv3d, temporal_fill: FillMode = "replicate"
-    ) -> "Conv3d":
+    def like(module: nn.Conv3d, temporal_fill: FillMode = "replicate") -> "Conv3d":
         stride = (1, *module.stride[1:])
         dilation = (1, *module.dilation[1:])
         for shape, name in zip(

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -465,10 +465,10 @@ class Conv2d(_ConvCoNd):
             padding_mode=module.padding_mode,
             temporal_fill=temporal_fill,
         )
+
         with torch.no_grad():
-            comodule.weight.copy_(module.weight)
-            if module.bias is not None:
-                comodule.bias.copy_(module.bias)
+            comodule.load_state_dict(module.state_dict())
+            
         return comodule
 
 

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -1,6 +1,7 @@
+from typing import Callable, Tuple
+
 import torch
 import torch.nn.functional as F
-from typing import Callable, Tuple
 from torch import Tensor, nn
 from torch.nn.modules.conv import (
     _ConvNd,
@@ -14,8 +15,8 @@ from torch.nn.modules.conv import (
 )
 
 from .interface import CoModule, FillMode, TensorPlaceholder
-from .utils import temporary_parameter
 from .logging import getLogger
+from .utils import temporary_parameter
 
 logger = getLogger(__name__)
 
@@ -468,7 +469,7 @@ class Conv2d(_ConvCoNd):
 
         with torch.no_grad():
             comodule.load_state_dict(module.state_dict())
-            
+
         return comodule
 
 

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -3,8 +3,7 @@ from typing import Callable, Tuple
 
 import torch
 import torch.nn.functional as F
-from torch import Tensor
-from torch import nn
+from torch import Tensor, nn
 from torch.nn.modules.conv import (
     _ConvNd,
     _pair,

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -1,24 +1,26 @@
 """ Register modules with conversion system and 3rd-party libraries """
 
-from torch import nn
-from .conv import Conv1d, Conv2d, Conv3d
-from .pooling import (
-    AvgPool1d,
-    MaxPool1d,
-    AvgPool2d,
-    MaxPool2d,
-    AdaptiveAvgPool2d,
-    AdaptiveMaxPool2d,
-    AvgPool3d,
-    MaxPool3d,
-    AdaptiveAvgPool3d,
-    AdaptiveMaxPool3d,
-)
-from .container import Sequential
-from .batchnorm import BatchNorm2d
-from .logging import getLogger
-from .interface import CoModule
 from typing import Type
+
+from torch import nn
+
+from .batchnorm import BatchNorm2d
+from .container import Sequential
+from .conv import Conv1d, Conv2d, Conv3d
+from .interface import CoModule
+from .logging import getLogger
+from .pooling import (
+    AdaptiveAvgPool2d,
+    AdaptiveAvgPool3d,
+    AdaptiveMaxPool2d,
+    AdaptiveMaxPool3d,
+    AvgPool1d,
+    AvgPool2d,
+    AvgPool3d,
+    MaxPool1d,
+    MaxPool2d,
+    MaxPool3d,
+)
 
 logger = getLogger(__name__)
 

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -1,0 +1,126 @@
+""" Register modules with conversion system and 3rd-party libraries """
+
+from torch import nn
+from .conv import Conv1d, Conv2d, Conv3d
+from .pooling import (
+    AvgPool1d,
+    MaxPool1d,
+    AvgPool2d,
+    MaxPool2d,
+    AdaptiveAvgPool2d,
+    AdaptiveMaxPool2d,
+    AvgPool3d,
+    MaxPool3d,
+    AdaptiveAvgPool3d,
+    AdaptiveMaxPool3d,
+)
+from .container import Sequential
+from .batchnorm import BatchNorm2d
+from .logging import getLogger
+from .interface import CoModule
+from typing import Type
+
+logger = getLogger(__name__)
+
+
+# A mapping from torch.nn modules to continual modules
+MODULE_MAPPING = {}
+
+
+class ModuleNotRegisteredError(Exception):
+    ...
+
+
+def register(TorchNnModule: Type[nn.Module], CoClass: Type[CoModule]):
+    if not callable(getattr(CoClass, "build_from", None)):
+        raise ModuleNotRegisteredError(
+            f"To register {CoClass.__name__}, it should implement a `build_from` method:"
+            """
+            from continual.utils import register
+
+            @register(TorchModule)
+            class ContinualModule:
+
+                @staticmethod
+                def build_from(module: TorchModule) -> "ContinualModule":
+                    ...
+        """
+        )
+    MODULE_MAPPING[TorchNnModule] = CoClass
+    return CoClass
+
+
+def continual(module: nn.Module) -> CoModule:
+    if type(module) not in MODULE_MAPPING:
+        raise ModuleNotRegisteredError(
+            f"A registered conversion for {module.__name__} was not found. "
+            "You can register a custom conversion as follows:"
+            """
+            from continual.utils import register
+
+            @register(TorchModule)
+            class ContinualModule:
+
+                @staticmethod
+                def build_from(module: TorchModule) -> "ContinualModule":
+                    ...
+            """
+        )
+    return MODULE_MAPPING[type(module)].build_from(module)
+
+
+# Register modules with our conversion system
+
+# Conv
+register(nn.Conv1d, Conv1d)
+register(nn.Conv2d, Conv2d)
+register(nn.Conv3d, Conv3d)
+
+# Pooling
+register(nn.AvgPool1d, AvgPool1d)
+register(nn.MaxPool1d, MaxPool1d)
+register(nn.AvgPool2d, AvgPool2d)
+register(nn.MaxPool2d, MaxPool2d)
+register(nn.AdaptiveAvgPool2d, AdaptiveAvgPool2d)
+register(nn.AdaptiveMaxPool2d, AdaptiveMaxPool2d)
+register(nn.AvgPool3d, AvgPool3d)
+register(nn.MaxPool3d, MaxPool3d)
+register(nn.AdaptiveAvgPool3d, AdaptiveAvgPool3d)
+register(nn.AdaptiveMaxPool3d, AdaptiveMaxPool3d)
+
+# BatchNorm
+register(nn.BatchNorm2d, BatchNorm2d)
+
+# Container
+register(nn.Sequential, Sequential)
+
+
+# Register modules in `ptflops`
+try:
+    from ptflops import flops_counter as fc
+
+    # BatchNorm
+    fc.MODULES_MAPPING[BatchNorm2d] = fc.bn_flops_counter_hook
+
+    # Conv
+    fc.MODULES_MAPPING[Conv1d] = fc.conv_flops_counter_hook
+    fc.MODULES_MAPPING[Conv2d] = fc.conv_flops_counter_hook
+    fc.MODULES_MAPPING[Conv3d] = fc.conv_flops_counter_hook
+
+    # Pooling
+    fc.MODULES_MAPPING[AvgPool1d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[MaxPool1d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AvgPool2d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[MaxPool2d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AdaptiveAvgPool2d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AdaptiveMaxPool2d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AvgPool3d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[MaxPool3d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AdaptiveAvgPool3d] = fc.pool_flops_counter_hook
+    fc.MODULES_MAPPING[AdaptiveMaxPool3d] = fc.pool_flops_counter_hook
+
+
+except ModuleNotFoundError:
+    pass
+except Exception as e:
+    logger.warning(f"Failed to add flops_counter_hook: {e}")

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -3,13 +3,14 @@ from typing import Tuple
 import torch
 from torch import Tensor
 
-from .interface import _CoModule
-from .utils import FillMode
+from .interface import CoModule, FillMode
 
 State = Tuple[Tensor, int]
 
+__all__ = ["Delay"]
 
-class Delay(torch.nn.Module, _CoModule):
+
+class Delay(torch.nn.Module, CoModule):
     """Continual delay modules
 
     NB: This module only introduces a delay in the continual modes, i.e. on `forward_step` and `forward_steps`

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -19,7 +19,7 @@ class Delay(torch.nn.Module, CoModule):
     def __init__(
         self,
         delay: int,
-        temporal_fill: FillMode = "replicate",
+        temporal_fill: FillMode = "zeros",
     ):
         assert delay > 0
         assert temporal_fill in {"zeros", "replicate"}
@@ -79,10 +79,7 @@ class Delay(torch.nn.Module, CoModule):
         return output, (buffer, new_index)
 
     def forward_steps(self, input: Tensor) -> Tensor:
-        # Pass into delay line, but discard output
-        outs = []
-        for t in range(input.shape[3]):
-            outs.append(self.forward_step(input[:, :, t]))
+        outs = [self.forward_step(input[:, :, t]) for t in range(input.shape[2])]
 
         if len(outs) > 0:
             outs = torch.stack(outs, dim=2)
@@ -98,3 +95,6 @@ class Delay(torch.nn.Module, CoModule):
     @property
     def delay(self) -> int:
         return self._delay
+
+    def extra_repr(self):
+        return f"{self.delay}"

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -10,6 +10,11 @@ State = Tuple[Tensor, int]
 
 
 class Delay(torch.nn.Module, _CoModule):
+    """Continual delay modules
+
+    NB: This module only introduces a delay in the continual modes, i.e. on `forward_step` and `forward_steps`
+    """
+
     def __init__(
         self,
         delay: int,
@@ -51,13 +56,13 @@ class Delay(torch.nn.Module, _CoModule):
         else:
             return None
 
-    def forward(self, input: Tensor) -> Tensor:
-        output, (self.state_buffer, self.state_index) = self._forward(
+    def forward_step(self, input: Tensor) -> Tensor:
+        output, (self.state_buffer, self.state_index) = self._forward_step(
             input, self.get_state()
         )
         return output
 
-    def _forward(self, input: Tensor, prev_state: State) -> Tuple[Tensor, State]:
+    def _forward_step(self, input: Tensor, prev_state: State) -> Tuple[Tensor, State]:
         if prev_state is None:
             buffer, index = self.init_state(input)
         else:
@@ -72,15 +77,15 @@ class Delay(torch.nn.Module, _CoModule):
 
         return output, (buffer, new_index)
 
-    def forward_regular(self, input: Tensor) -> Tensor:
+    def forward_steps(self, input: Tensor) -> Tensor:
         # Pass into delay line, but discard output
         self.forward(input)
 
-        # No delay during forward_regular
+        # No delay during forward_steps
         return input
 
-    def forward_regular_unrolled(self, input: Tensor) -> Tensor:
-        # No delay during forward_regular
+    def forward(self, input: Tensor) -> Tensor:
+        # No delay during forward_steps
         return input
 
     @property

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -80,13 +80,19 @@ class Delay(torch.nn.Module, CoModule):
 
     def forward_steps(self, input: Tensor) -> Tensor:
         # Pass into delay line, but discard output
-        self.forward(input)
+        outs = []
+        for t in range(input.shape[3]):
+            outs.append(self.forward_step(input[:, :, t]))
 
-        # No delay during forward_steps
-        return input
+        if len(outs) > 0:
+            outs = torch.stack(outs, dim=2)
+        else:
+            outs = torch.tensor([])  # pragma: no cover
+
+        return outs
 
     def forward(self, input: Tensor) -> Tensor:
-        # No delay during forward_steps
+        # No delay during regular forward
         return input
 
     @property

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -25,6 +25,7 @@ class CoModule(ABC):
                 "forward",
                 "a forward computation which is identical to a regular non-continual forward.",
             ),
+            ("clean_state", "an internal state clean-up."),
         ]:
             assert callable(
                 getattr(cls, fn, None)
@@ -47,20 +48,20 @@ class CoModule(ABC):
         """Clip-wise forward without state initialisation, but which is identical to the non-continual component"""
         ...  # pragma: no cover
 
-    @property
-    def delay(self) -> int:
-        """Temporal delay of the module
+    # @property
+    # def delay(self) -> int:
+    #     """Temporal delay of the module
 
-        Returns:
-            int: Temporal delay of the module
-        """
-        ...  # pragma: no cover
+    #     Returns:
+    #         int: Temporal delay of the module
+    #     """
+    #     ...  # pragma: no cover
 
-    def clean_state(self):
-        """Clean module state
-        This serves as a dummy function for modules which do not require state-cleanup
-        """
-        ...  # pragma: no cover
+    # def clean_state(self):
+    #     """Clean module state
+    #     This serves as a dummy function for modules which do not require state-cleanup
+    #     """
+    #     ...  # pragma: no cover
 
 
 class TensorPlaceholder:

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -10,14 +10,14 @@ class _CoModule(ABC):
 
     def __init_subclass__(cls) -> None:
         for fn, description in [
-            ("forward", "frame-wise forward computation"),
+            ("forward_step", "forward computation for a single temporal step"),
             (
-                "forward_regular",
-                "clip-wise forward computation with state initialisation",
+                "forward_step",
+                "forward computation for multiple temporal step",
             ),
             (
-                "forward_regular_unrolled",
-                "clip-wise forward without state initialisation, but which is identical to the non-continual component",
+                "forward",
+                "a forward computation which is identical to a regular non-continual forward.",
             ),
         ]:
             assert callable(
@@ -28,15 +28,15 @@ class _CoModule(ABC):
             type(getattr(cls, "delay", None)) == property
         ), "A CoModule should implement a `delay` property."
 
+    def forward_step(self, input: Tensor) -> Tensor:
+        """Clip-wise forward computation with state initialisation"""
+        ...  # pragma: no cover
+
+    def forward_steps(self, input: Tensor) -> Tensor:
+        """Clip-wise forward computation with state initialisation"""
+        ...  # pragma: no cover
+
     def forward(self, input: Tensor) -> Tensor:
-        """Clip-wise forward computation with state initialisation"""
-        ...  # pragma: no cover
-
-    def forward_regular(self, input: Tensor) -> Tensor:
-        """Clip-wise forward computation with state initialisation"""
-        ...  # pragma: no cover
-
-    def forward_regular_unrolled(self, input: Tensor) -> Tensor:
         """Clip-wise forward without state initialisation, but which is identical to the non-continual component"""
         ...  # pragma: no cover
 

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -1,6 +1,7 @@
 from abc import ABC
 from enum import Enum
 from typing import Tuple
+
 from torch import Tensor
 
 

--- a/continual/logging.py
+++ b/continual/logging.py
@@ -8,7 +8,7 @@ def _process_rank():
     try:
         import pytorch_lightning as pl
 
-        if pl.utilities._HOROVOD_AVAILABLE:
+        if pl.utilities._HOROVOD_AVAILABLE:  # pragma: no cover
             import horovod.torch as hvd
 
             hvd.init()
@@ -16,7 +16,7 @@ def _process_rank():
         else:
             return pl.utilities.rank_zero_only.rank
 
-    except ModuleNotFoundError:
+    except ModuleNotFoundError:  # pragma: no cover
         return 0
 
 

--- a/continual/logging.py
+++ b/continual/logging.py
@@ -1,7 +1,7 @@
 """ PyTorch Lightning compatible logging """
 
-from functools import wraps
 import logging
+from functools import wraps
 
 
 def _process_rank():

--- a/continual/logging.py
+++ b/continual/logging.py
@@ -1,0 +1,39 @@
+""" PyTorch Lightning compatible logging """
+
+from functools import wraps
+import logging
+
+
+def _process_rank():
+    try:
+        import pytorch_lightning as pl
+
+        if pl.utilities._HOROVOD_AVAILABLE:
+            import horovod.torch as hvd
+
+            hvd.init()
+            return hvd.rank()
+        else:
+            return pl.utilities.rank_zero_only.rank
+
+    except ModuleNotFoundError:
+        return 0
+
+
+process_rank = _process_rank()
+
+
+def if_rank_zero(fn):
+    @wraps(fn)
+    def wrapped(*args, **kwargs):
+        global process_rank
+        if process_rank == 0:
+            fn(*args, **kwargs)
+
+    return wrapped
+
+
+def getLogger(name):
+    logger = logging.getLogger(name)
+    logger._log = if_rank_zero(logger._log)
+    return logger

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -56,7 +56,7 @@ def _co_window_pooled(  # noqa: C901
             self,
             temporal_kernel_size: int,
             temporal_dilation: int = 1,
-            temporal_fill: FillMode = "replicate",
+            temporal_fill: FillMode = "zeros",
             *args,
             **kwargs,
         ):

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -3,16 +3,7 @@ from typing import Callable, Tuple, Type, TypeVar
 import torch
 import torch.nn.functional as F
 from torch import Tensor
-from torch.nn.modules.pooling import (
-    AdaptiveAvgPool1d,
-    AdaptiveAvgPool2d,
-    AdaptiveMaxPool1d,
-    AdaptiveMaxPool2d,
-    AvgPool1d,
-    AvgPool2d,
-    MaxPool1d,
-    MaxPool2d,
-)
+from torch import nn
 
 from .interface import _CoModule
 from .utils import FillMode
@@ -22,16 +13,16 @@ State = Tuple[Tensor, int]
 T = TypeVar("T")
 
 __all__ = [
-    "AvgPoolCo1d",
-    "MaxPoolCo1d",
-    "AvgPoolCo2d",
-    "MaxPoolCo2d",
-    "AdaptiveAvgPoolCo2d",
-    "AdaptiveMaxPoolCo2d",
-    "AvgPoolCo3d",
-    "MaxPoolCo3d",
-    "AdaptiveAvgPoolCo3d",
-    "AdaptiveMaxPoolCo3d",
+    "AvgPool1d",
+    "MaxPool1d",
+    "AvgPool2d",
+    "MaxPool2d",
+    "AdaptiveAvgPool2d",
+    "AdaptiveMaxPool2d",
+    "AvgPool3d",
+    "MaxPool3d",
+    "AdaptiveAvgPool3d",
+    "AdaptiveMaxPool3d",
 ]
 
 State = Tuple[Tensor, int]
@@ -60,14 +51,14 @@ def _co_window_pooled(  # noqa: C901
     assert cls in {
         _DummyAvgPool,
         _DummyMaxPool,
-        AdaptiveAvgPool1d,
-        MaxPool1d,
-        AvgPool1d,
-        AdaptiveMaxPool1d,
-        AvgPool2d,
-        MaxPool2d,
-        AdaptiveAvgPool2d,
-        AdaptiveMaxPool2d,
+        nn.AdaptiveAvgPool1d,
+        nn.MaxPool1d,
+        nn.AvgPool1d,
+        nn.AdaptiveMaxPool1d,
+        nn.AvgPool2d,
+        nn.MaxPool2d,
+        nn.AdaptiveAvgPool2d,
+        nn.AdaptiveMaxPool2d,
     }
 
     class CoPool1d(_CoModule, cls):
@@ -98,7 +89,7 @@ def _co_window_pooled(  # noqa: C901
             ]
 
             self.temporal_pool = (
-                AdaptiveAvgPool1d if "avg" in class_name else AdaptiveMaxPool1d
+                nn.AdaptiveAvgPool1d if "avg" in class_name else nn.AdaptiveMaxPool1d
             )(1)
 
             if self.temporal_dilation > 1:
@@ -279,7 +270,7 @@ def _co_window_pooled(  # noqa: C901
     return CoPool1d
 
 
-class AvgPoolCo1d(_co_window_pooled(_DummyAvgPool, F.avg_pool1d)):
+class AvgPool1d(_co_window_pooled(_DummyAvgPool, F.avg_pool1d)):
     """
     Continual Average Pool in 1D
 
@@ -289,7 +280,7 @@ class AvgPoolCo1d(_co_window_pooled(_DummyAvgPool, F.avg_pool1d)):
     ...
 
 
-class MaxPoolCo1d(_co_window_pooled(_DummyMaxPool, F.max_pool1d)):
+class MaxPool1d(_co_window_pooled(_DummyMaxPool, F.max_pool1d)):
     """
     Continual Max Pool in 1D
 
@@ -299,7 +290,7 @@ class MaxPoolCo1d(_co_window_pooled(_DummyMaxPool, F.max_pool1d)):
     ...
 
 
-class AvgPoolCo2d(_co_window_pooled(AvgPool1d, F.avg_pool2d)):
+class AvgPool2d(_co_window_pooled(nn.AvgPool1d, F.avg_pool2d)):
     """
     Continual Average Pool in 2D
 
@@ -309,7 +300,7 @@ class AvgPoolCo2d(_co_window_pooled(AvgPool1d, F.avg_pool2d)):
     ...
 
 
-class MaxPoolCo2d(_co_window_pooled(MaxPool1d, F.max_pool2d)):
+class MaxPool2d(_co_window_pooled(nn.MaxPool1d, F.max_pool2d)):
     """
     Continual Max Pool in 2D
 
@@ -319,7 +310,7 @@ class MaxPoolCo2d(_co_window_pooled(MaxPool1d, F.max_pool2d)):
     ...
 
 
-class AdaptiveAvgPoolCo2d(_co_window_pooled(AdaptiveAvgPool1d)):
+class AdaptiveAvgPool2d(_co_window_pooled(nn.AdaptiveAvgPool1d)):
     """
     Continual Adaptive Average Pool in 2D
 
@@ -329,7 +320,7 @@ class AdaptiveAvgPoolCo2d(_co_window_pooled(AdaptiveAvgPool1d)):
     ...
 
 
-class AdaptiveMaxPoolCo2d(_co_window_pooled(AdaptiveMaxPool1d)):
+class AdaptiveMaxPool2d(_co_window_pooled(nn.AdaptiveMaxPool1d)):
     """
     Continual Adaptive Max Pool in 2D
 
@@ -339,7 +330,7 @@ class AdaptiveMaxPoolCo2d(_co_window_pooled(AdaptiveMaxPool1d)):
     ...
 
 
-class AvgPoolCo3d(_co_window_pooled(AvgPool2d, F.avg_pool3d)):
+class AvgPool3d(_co_window_pooled(nn.AvgPool2d, F.avg_pool3d)):
     """
     Continual Average Pool in 3D
 
@@ -349,7 +340,7 @@ class AvgPoolCo3d(_co_window_pooled(AvgPool2d, F.avg_pool3d)):
     ...
 
 
-class MaxPoolCo3d(_co_window_pooled(MaxPool2d, F.max_pool3d)):
+class MaxPool3d(_co_window_pooled(nn.MaxPool2d, F.max_pool3d)):
     """
     Continual Max Pool in 3D
 
@@ -359,21 +350,21 @@ class MaxPoolCo3d(_co_window_pooled(MaxPool2d, F.max_pool3d)):
     ...
 
 
-class AdaptiveAvgPoolCo3d(_co_window_pooled(AdaptiveAvgPool2d)):
+class AdaptiveAvgPool3d(_co_window_pooled(nn.AdaptiveAvgPool2d)):
     """
     Continual Adaptive Average Pool in 3D
 
-    This is the continual version of the regular :class:`torch.nn.AdaptiveAvgPool3d`
+    This is the continual version of the regular :class:`torch.nn.nn.AdaptiveAvgPool3d`
     """
 
     ...
 
 
-class AdaptiveMaxPoolCo3d(_co_window_pooled(AdaptiveMaxPool2d)):
+class AdaptiveMaxPool3d(_co_window_pooled(nn.AdaptiveMaxPool2d)):
     """
     Continual Adaptive Max Pool in 3D
 
-    This is the continual version of the regular :class:`torch.nn.AdaptiveMaxPool3d`
+    This is the continual version of the regular :class:`torch.nn.nn.AdaptiveMaxPool3d`
     """
 
     ...

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -1,3 +1,4 @@
+from functools import partial
 from typing import Callable, Tuple, Type, TypeVar
 
 import torch
@@ -5,7 +6,6 @@ import torch.nn.functional as F
 from torch import Tensor, nn
 
 from .interface import CoModule, FillMode
-from functools import partial
 
 State = Tuple[Tensor, int]
 

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -2,8 +2,7 @@ from typing import Callable, Tuple, Type, TypeVar
 
 import torch
 import torch.nn.functional as F
-from torch import Tensor
-from torch import nn
+from torch import Tensor, nn
 
 from .interface import _CoModule
 from .utils import FillMode

--- a/continual/ptflops.py
+++ b/continual/ptflops.py
@@ -1,0 +1,53 @@
+""" Register modules with `ptflops` """
+
+from .conv import Conv1d, Conv2d, Conv3d
+from .pooling import (
+    AvgPool1d,
+    MaxPool1d,
+    AvgPool2d,
+    MaxPool2d,
+    AdaptiveAvgPool2d,
+    AdaptiveMaxPool2d,
+    AvgPool3d,
+    MaxPool3d,
+    AdaptiveAvgPool3d,
+    AdaptiveMaxPool3d,
+)
+from .batchnorm import BatchNorm2d
+from .logging import getLogger
+
+logger = getLogger(__name__)
+
+
+# Register modules in `ptflops`
+def register_ptflops():
+    try:
+        from ptflops import flops_counter as fc
+
+        # BatchNorm
+        fc.MODULES_MAPPING[BatchNorm2d] = fc.bn_flops_counter_hook
+
+        # Conv
+        fc.MODULES_MAPPING[Conv1d] = fc.conv_flops_counter_hook
+        fc.MODULES_MAPPING[Conv2d] = fc.conv_flops_counter_hook
+        fc.MODULES_MAPPING[Conv3d] = fc.conv_flops_counter_hook
+
+        # Pooling
+        fc.MODULES_MAPPING[AvgPool1d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[MaxPool1d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AvgPool2d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[MaxPool2d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AdaptiveAvgPool2d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AdaptiveMaxPool2d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AvgPool3d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[MaxPool3d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AdaptiveAvgPool3d] = fc.pool_flops_counter_hook
+        fc.MODULES_MAPPING[AdaptiveMaxPool3d] = fc.pool_flops_counter_hook
+
+    except ModuleNotFoundError:  # pragma: no cover
+        pass
+    except Exception as e:  # pragma: no cover
+        logger.warning(f"Failed to add flops_counter_hook: {e}")
+
+
+register_ptflops()

--- a/continual/ptflops.py
+++ b/continual/ptflops.py
@@ -1,20 +1,20 @@
 """ Register modules with `ptflops` """
 
-from .conv import Conv1d, Conv2d, Conv3d
-from .pooling import (
-    AvgPool1d,
-    MaxPool1d,
-    AvgPool2d,
-    MaxPool2d,
-    AdaptiveAvgPool2d,
-    AdaptiveMaxPool2d,
-    AvgPool3d,
-    MaxPool3d,
-    AdaptiveAvgPool3d,
-    AdaptiveMaxPool3d,
-)
 from .batchnorm import BatchNorm2d
+from .conv import Conv1d, Conv2d, Conv3d
 from .logging import getLogger
+from .pooling import (
+    AdaptiveAvgPool2d,
+    AdaptiveAvgPool3d,
+    AdaptiveMaxPool2d,
+    AdaptiveMaxPool3d,
+    AvgPool1d,
+    AvgPool2d,
+    AvgPool3d,
+    MaxPool1d,
+    MaxPool2d,
+    MaxPool3d,
+)
 
 logger = getLogger(__name__)
 

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -21,6 +21,9 @@ class Zero(nn.Module, CoModule):
     def delay(self) -> int:
         return 0
 
+    def clean_state(self):
+        ...
+
 
 def unsqueezed(instance: nn.Module, dim: int = 2):
     def decorator(func: Callable[[Tensor], Tensor]):

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -1,30 +1,13 @@
 from contextlib import contextmanager
-from enum import Enum
 from functools import reduce, wraps
-from typing import Callable, Tuple
+from typing import Callable
 
 from torch import Tensor
-from torch.nn import Module
-
-from .interface import _CoModule
-
-
-class TensorPlaceholder:
-    shape: Tuple[int]
-
-    def __init__(self, shape: Tuple[int]):
-        self.shape = shape
-
-    def size(self):
-        return self.shape
+from torch import nn
+from .interface import CoModule
 
 
-class FillMode(Enum):
-    REPLICATE = "replicate"
-    ZEROS = "zeros"
-
-
-class Zero(Module, _CoModule):
+class Zero(nn.Module, CoModule):
     def forward_step(self, input: Tensor) -> Tensor:
         return 0
 
@@ -34,8 +17,12 @@ class Zero(Module, _CoModule):
     def forward(self, input: Tensor) -> Tensor:
         return 0
 
+    @property
+    def delay(self) -> int:
+        return 0
 
-def continual(instance: Module, dim: int = 2):
+
+def unsqueezed(instance: nn.Module, dim: int = 2):
     def decorator(func: Callable[[Tensor], Tensor]):
         @wraps(func)
         def call(x: Tensor) -> Tensor:

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -2,8 +2,8 @@ from contextlib import contextmanager
 from functools import reduce, wraps
 from typing import Callable
 
-from torch import Tensor
-from torch import nn
+from torch import Tensor, nn
+
 from .interface import CoModule
 
 

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -25,13 +25,13 @@ class FillMode(Enum):
 
 
 class Zero(Module, _CoModule):
+    def forward_step(self, input: Tensor) -> Tensor:
+        return 0
+
+    def forward_steps(self, input: Tensor) -> Tensor:
+        return 0
+
     def forward(self, input: Tensor) -> Tensor:
-        return 0
-
-    def forward_regular(self, input: Tensor) -> Tensor:
-        return 0
-
-    def forward_regular_unrolled(self, input: Tensor) -> Tensor:
         return 0
 
 
@@ -46,8 +46,8 @@ def continual(instance: Module, dim: int = 2):
 
         return call
 
-    instance.forward_regular_unrolled = instance.forward
-    instance.forward_regular = instance.forward
+    instance.forward = instance.forward
+    instance.forward_steps = instance.forward
     instance.forward = decorator(instance.forward)
 
     return instance

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -6,3 +6,4 @@ pytest
 pytest-cov
 ptflops>=0.6
 numpy
+pytorch_lightning

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,3 +5,4 @@ isort>=5.7
 pytest
 pytest-cov
 ptflops>=0.6
+numpy

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.1.2",
+    version="0.2.0",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -1,0 +1,50 @@
+import torch
+from torch import nn
+
+import continual as co
+
+torch.manual_seed(42)
+
+
+def test_sequential():
+    S = 3
+
+    long_example_clip = torch.normal(mean=torch.zeros(8 * 3 * 3)).reshape(
+        (1, 1, 8, 3, 3)
+    )
+    next_example_frame = torch.normal(mean=torch.zeros(3 * 3)).reshape((1, 1, 3, 3))
+    long_next_example_clip = torch.stack(
+        [
+            *[long_example_clip[:, :, i] for i in range(1, 8)],
+            next_example_frame,
+        ],
+        dim=2,
+    )
+
+    seq = nn.Sequential(
+        nn.Conv3d(
+            in_channels=1,
+            out_channels=1,
+            kernel_size=(5, S, S),
+            bias=True,
+            padding=(0, 1, 1),
+            padding_mode="zeros",
+        ),
+        nn.Conv3d(
+            in_channels=1,
+            out_channels=1,
+            kernel_size=(3, S, S),
+            bias=True,
+            padding=(0, 1, 1),
+            padding_mode="zeros",
+        ),
+        nn.MaxPool3d(kernel_size=(2, 2, 2)),
+    )
+
+    coseq = co.Sequential.build_from(seq)
+
+    # Forward results are identical
+    output = seq.forward(long_example_clip)
+    co_output = coseq.forward(long_example_clip)
+
+    assert torch.allclose(output, co_output)

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -9,17 +9,9 @@ torch.manual_seed(42)
 def test_sequential():
     S = 3
 
-    long_example_clip = torch.normal(mean=torch.zeros(8 * 3 * 3)).reshape(
-        (1, 1, 8, 3, 3)
+    long_example_clip = torch.normal(mean=torch.zeros(10 * 3 * 3)).reshape(
+        (1, 1, 10, 3, 3)
     )
-    # next_example_frame = torch.normal(mean=torch.zeros(3 * 3)).reshape((1, 1, 3, 3))
-    # long_next_example_clip = torch.stack(
-    #     [
-    #         *[long_example_clip[:, :, i] for i in range(1, 8)],
-    #         next_example_frame,
-    #     ],
-    #     dim=2,
-    # )
 
     seq = nn.Sequential(
         nn.Conv3d(
@@ -38,7 +30,7 @@ def test_sequential():
             padding=(0, 1, 1),
             padding_mode="zeros",
         ),
-        nn.MaxPool3d(kernel_size=(2, 2, 2)),
+        nn.MaxPool3d(kernel_size=(1, 2, 2)),
     )
 
     coseq = co.Sequential.build_from(seq)
@@ -46,5 +38,11 @@ def test_sequential():
     # Forward results are identical
     output = seq.forward(long_example_clip)
     co_output = coseq.forward(long_example_clip)
-
     assert torch.allclose(output, co_output)
+
+    # Alternative forwards
+    co_output_firsts = coseq.forward_steps(long_example_clip[:, :, :-1])
+    assert torch.allclose(output[:, :, :-1], co_output_firsts)
+
+    co_output_last = coseq.forward_step(long_example_clip[:, :, -1])
+    assert torch.allclose(output[:, :, -1], co_output_last)

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -35,6 +35,8 @@ def test_sequential():
 
     coseq = co.Sequential.build_from(seq)
 
+    assert coseq.delay == (5 - 1) + (3 - 1)
+
     # Forward results are identical
     output = seq.forward(long_example_clip)
     co_output = coseq.forward(long_example_clip)
@@ -46,3 +48,79 @@ def test_sequential():
 
     co_output_last = coseq.forward_step(long_example_clip[:, :, -1])
     assert torch.allclose(output[:, :, -1], co_output_last)
+
+    # Clean state can be used to restart seq computation
+    coseq.clean_state()
+    co_output_firsts = coseq.forward_steps(long_example_clip[:, :, :-1])
+    assert torch.allclose(output[:, :, :-1], co_output_firsts)
+
+
+def test_sum_aggregation():
+    ones = torch.ones((1, 2, 4, 3, 3))
+    twos = torch.ones((1, 2, 4, 3, 3)) * 2
+    res = co.container.parallel_sum([ones, ones])
+    assert torch.equal(res, twos)
+
+
+def test_concat_aggregation():
+    ones = torch.ones((1, 2, 4, 3, 3))
+    twos = torch.ones((1, 2, 4, 3, 3)) * 2
+    res = co.container.parallel_concat([ones, twos])
+    assert res.shape == (1, 4, 4, 3, 3)
+    assert torch.equal(res[:, :2], ones)
+    assert torch.equal(res[:, 2:], twos)
+
+
+def test_residual():
+    input = torch.normal(mean=torch.zeros(6 * 3 * 3)).reshape((1, 1, 6, 3, 3))
+
+    t_pad = 1
+    conv = nn.Conv3d(1, 1, (3, 3, 3), padding=(t_pad, 1, 1))
+
+    co_conv = co.Conv3d(1, 1, (3, 3, 3), padding=(t_pad, 1, 1))
+    co_conv.load_state_dict(conv.state_dict())
+
+    co_res = co.Residual(co_conv)
+
+    # Target behavior: Discard outputs from temporal padding
+    target = (conv(input) + input)[:, :, 1:-1]
+
+    # forward
+    out_manual_res = co_conv.forward(input) + input[:, :, 1:-1]
+    assert torch.equal(out_manual_res, target)
+
+    out_res = co_res.forward(input)
+    assert torch.equal(out_res, target)
+
+    # forward_steps
+    out_firsts = co_res.forward_steps(input[:, :, :-1])
+    assert torch.allclose(
+        out_firsts[:, :, co_res.delay + t_pad : -1], target[:, :, :-2]
+    )
+
+    # forward_step
+    out_last = co_res.forward_step(input[:, :, -1])
+    assert torch.allclose(out_last, target[:, :, -1])
+
+
+def test_parallel():
+    input = torch.normal(mean=torch.zeros(7 * 5 * 5)).reshape((1, 1, 7, 5, 5))
+
+    c5 = co.Conv3d(1, 1, (5, 5, 5), padding=(2, 2, 2))
+    c3 = co.Conv3d(1, 1, (3, 3, 3), padding=(1, 1, 1))
+    c1 = co.Conv3d(1, 1, (1, 1, 1), padding=(0, 0, 0))
+    par = co.Parallel(c5, c3, c1)
+
+    # forward
+    out_all = par(input)
+    assert out_all.shape == (1, 1, 3, 5, 5)
+
+    # forward_steps
+    out_firsts = par.forward_steps(input[:, :, :-1])
+    assert torch.allclose(out_firsts[:, :, 2 * par.delay : -1], out_all[:, :, :-2])
+
+    # forward_step
+    out_last = par.forward_step(input[:, :, -1])
+    assert torch.allclose(out_last, out_all[:, :, -1])
+
+    par.clean_state()

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -59,7 +59,7 @@ def test_sum_aggregation():
     ones = torch.ones((1, 2, 4, 3, 3))
     twos = torch.ones((1, 2, 4, 3, 3)) * 2
     res = co.container.parallel_sum([ones, ones])
-    assert torch.equal(res, twos)
+    assert torch.allclose(res, twos)
 
 
 def test_concat_aggregation():
@@ -67,8 +67,8 @@ def test_concat_aggregation():
     twos = torch.ones((1, 2, 4, 3, 3)) * 2
     res = co.container.parallel_concat([ones, twos])
     assert res.shape == (1, 4, 4, 3, 3)
-    assert torch.equal(res[:, :2], ones)
-    assert torch.equal(res[:, 2:], twos)
+    assert torch.allclose(res[:, :2], ones)
+    assert torch.allclose(res[:, 2:], twos)
 
 
 def test_residual():
@@ -87,10 +87,10 @@ def test_residual():
 
     # forward
     out_manual_res = co_conv.forward(input) + input[:, :, 1:-1]
-    assert torch.equal(out_manual_res, target)
+    assert torch.allclose(out_manual_res, target)
 
     out_res = co_res.forward(input)
-    assert torch.equal(out_res, target)
+    assert torch.allclose(out_res, target)
 
     # forward_steps
     out_firsts = co_res.forward_steps(input[:, :, :-1])

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -12,14 +12,14 @@ def test_sequential():
     long_example_clip = torch.normal(mean=torch.zeros(8 * 3 * 3)).reshape(
         (1, 1, 8, 3, 3)
     )
-    next_example_frame = torch.normal(mean=torch.zeros(3 * 3)).reshape((1, 1, 3, 3))
-    long_next_example_clip = torch.stack(
-        [
-            *[long_example_clip[:, :, i] for i in range(1, 8)],
-            next_example_frame,
-        ],
-        dim=2,
-    )
+    # next_example_frame = torch.normal(mean=torch.zeros(3 * 3)).reshape((1, 1, 3, 3))
+    # long_next_example_clip = torch.stack(
+    #     [
+    #         *[long_example_clip[:, :, i] for i in range(1, 8)],
+    #         next_example_frame,
+    #     ],
+    #     dim=2,
+    # )
 
     seq = nn.Sequential(
         nn.Conv3d(

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -2,7 +2,7 @@ import torch
 from torch import nn
 
 import continual as co
-from continual.utils import TensorPlaceholder
+from continual.interface import TensorPlaceholder
 
 torch.manual_seed(42)
 
@@ -18,7 +18,7 @@ def test_Conv1d():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv1d.like(conv, "zeros")
+    co_conv = co.Conv1d.build_from(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -50,7 +50,7 @@ def test_Conv1d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv1d.like(conv, "zeros")
+    co_conv = co.Conv1d.build_from(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -82,7 +82,7 @@ def test_Conv2d():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv2d.like(conv, "zeros")
+    co_conv = co.Conv2d.build_from(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -118,7 +118,7 @@ def test_Conv2d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv2d.like(conv, "zeros")
+    co_conv = co.Conv2d.build_from(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -205,7 +205,7 @@ def test_basic_forward():
     )
     target = conv(example_clip)
 
-    coconv = co.Conv3d.like(conv)
+    coconv = co.Conv3d.build_from(conv)
     # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
@@ -234,7 +234,7 @@ def test_forward_long_kernel():
     )
     target = conv(example_clip)
 
-    coconv = co.Conv3d.like(conv)
+    coconv = co.Conv3d.build_from(conv)
     # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
@@ -263,7 +263,7 @@ def test_from_conv3d():
     )
     target = regular(example_clip)
 
-    co3 = co.Conv3d.like(regular)
+    co3 = co.Conv3d.build_from(regular)
 
     output = []
     for i in range(example_clip.shape[2]):
@@ -289,7 +289,7 @@ def test_from_conv3d_bad_shape():
     )
 
     # Also warns
-    co3 = co.Conv3d.like(regular)
+    co3 = co.Conv3d.build_from(regular)
 
     # Changed               V
     assert co3.dilation == (1, 2, 2)
@@ -318,7 +318,7 @@ def test_complex():
     )
     regular_output = regular(example_clip_large).detach()
 
-    co3 = co.Conv3d.like(regular, temporal_fill="zeros")
+    co3 = co.Conv3d.build_from(regular, temporal_fill="zeros")
     co3_output = co3.forward_steps(example_clip_large)
 
     assert torch.allclose(regular_output, co3_output, atol=5e-8)
@@ -333,12 +333,12 @@ def test_forward_continuation():
         padding=(1, 1, 1),
         padding_mode="zeros",
     )
-    coconv = co.Conv3d.like(conv, temporal_fill="zeros")
+    coconv = co.Conv3d.build_from(conv, temporal_fill="zeros")
 
     # Run batch inference and fill memory
     target1 = conv(example_clip)
     output1 = coconv.forward_steps(example_clip)
-    assert torch.allclose(target1, output1)
+    assert torch.allclose(target1, output1, atol=1e-7)
 
     # Next forward
     target2 = conv(next_example_clip)
@@ -379,9 +379,9 @@ def test_stacked_impulse_response():
 
     # Init continual
     cnn = [
-        co.Conv3d.like(conv1, temporal_fill="zeros"),
-        co.Conv3d.like(conv2, temporal_fill="zeros"),
-        co.Conv3d.like(conv2, temporal_fill="zeros"),
+        co.Conv3d.build_from(conv1, temporal_fill="zeros"),
+        co.Conv3d.build_from(conv2, temporal_fill="zeros"),
+        co.Conv3d.build_from(conv2, temporal_fill="zeros"),
     ]
 
     # Impulse
@@ -427,8 +427,8 @@ def test_stacked_no_pad():
     )
 
     # Init continual
-    coconv1 = co.Conv3d.like(conv1, temporal_fill="zeros")
-    coconv2 = co.Conv3d.like(conv2, temporal_fill="zeros")
+    coconv1 = co.Conv3d.build_from(conv1, temporal_fill="zeros")
+    coconv2 = co.Conv3d.build_from(conv2, temporal_fill="zeros")
 
     # Targets
     target11 = conv1(long_example_clip)

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -1,7 +1,7 @@
 import torch
 from torch import nn
 
-from continual import Conv1d, Conv2d, Conv3d
+import continual as co
 from continual.utils import TensorPlaceholder
 
 torch.manual_seed(42)
@@ -18,23 +18,23 @@ def test_Conv1d():
     target = conv(sample)
 
     # Continual
-    co_conv = Conv1d.from_regular(conv, "zeros")
+    co_conv = co.Conv1d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
     for i in range(sample.shape[2]):
-        output.append(co_conv(sample[:, :, i]))
+        output.append(co_conv.forward_step(sample[:, :, i]))
 
     # Match after delay of T - 1
     for t in range(sample.shape[2] - (T - 1)):
         assert torch.allclose(target[:, :, t], output[t + (T - 1)])
 
     # Whole time-series
-    output = co_conv.forward_regular(sample)
+    output = co_conv.forward_steps(sample)
     assert torch.allclose(target, output)
 
     # Exact computation
-    output2 = co_conv.forward_regular_unrolled(sample)
+    output2 = co_conv.forward(sample)
     assert torch.equal(target, output2)
 
 
@@ -50,12 +50,12 @@ def test_Conv1d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = Conv1d.from_regular(conv, "zeros")
+    co_conv = co.Conv1d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
     for i in range(sample.shape[2]):
-        output.append(co_conv(sample[:, :, i]))
+        output.append(co_conv.forward_step(sample[:, :, i]))
 
     # Match after delay of T - 1
     for t in range(sample.shape[2] - (T - 1)):
@@ -65,7 +65,7 @@ def test_Conv1d_stride():
             assert type(output[t + (T - 1)]) is TensorPlaceholder
 
     # Whole time-series
-    output = co_conv.forward_regular(sample)
+    output = co_conv.forward_steps(sample)
     assert torch.allclose(target, output)
 
 
@@ -82,23 +82,23 @@ def test_Conv2d():
     target = conv(sample)
 
     # Continual
-    co_conv = Conv2d.from_regular(conv, "zeros")
+    co_conv = co.Conv2d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
     for i in range(sample.shape[2]):
-        output.append(co_conv(sample[:, :, i]))
+        output.append(co_conv.forward_step(sample[:, :, i]))
 
     # Match after delay of T - 1
     for t in range(sample.shape[2] - (T - 1)):
         assert torch.allclose(target[:, :, t], output[t + (T - 1)])
 
     # Whole time-series
-    output = co_conv.forward_regular(sample)
+    output = co_conv.forward_steps(sample)
     assert torch.allclose(target, output)
 
     # Exact computation
-    output2 = co_conv.forward_regular_unrolled(sample)
+    output2 = co_conv.forward(sample)
     assert torch.equal(target, output2)
 
 
@@ -118,12 +118,12 @@ def test_Conv2d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = Conv2d.from_regular(conv, "zeros")
+    co_conv = co.Conv2d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
     for i in range(sample.shape[2]):
-        output.append(co_conv(sample[:, :, i]))
+        output.append(co_conv.forward_step(sample[:, :, i]))
 
     # Match after delay of T - 1
     for t in range(sample.shape[2] - (T - 1)):
@@ -133,7 +133,7 @@ def test_Conv2d_stride():
             assert type(output[t + (T - 1)]) is TensorPlaceholder
 
     # Whole time-series
-    output = co_conv.forward_regular(sample)
+    output = co_conv.forward_steps(sample)
     assert torch.allclose(target, output)
 
 
@@ -163,14 +163,14 @@ long_next_example_clip = torch.stack(
 def test_seperability():
     # Checks that the basic idea is sound
 
-    # Take an example input and pass it thorugh a Conv3D the traditional way
+    # Take an example input and pass it thorugh a co.Conv3D the traditional way
     regular = torch.nn.Conv3d(
         in_channels=1, out_channels=1, kernel_size=(T, S, S), bias=True
     )
 
     regular_output = regular(example_clip).detach()
 
-    # Take an example input and pass it thorugh a Conv3D the seperated way
+    # Take an example input and pass it thorugh a co.Conv3D the seperated way
     seperated = torch.nn.Conv3d(
         in_channels=1,
         out_channels=1,
@@ -205,8 +205,8 @@ def test_basic_forward():
     )
     target = conv(example_clip)
 
-    coconv = Conv3d.from_regular(conv)
-    # coconv = Conv3d(
+    coconv = co.Conv3d.from_regular(conv)
+    # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
     #     kernel_size=(S, T, T),
@@ -216,13 +216,13 @@ def test_basic_forward():
     # coconv.conv.weight = conv.weight
     # coconv.bias = conv.bias
 
-    _ = coconv(example_clip[:, :, 0])
-    _ = coconv(example_clip[:, :, 1])
-    x1 = coconv(example_clip[:, :, 2])
-    x2 = coconv(example_clip[:, :, 3])
+    _ = coconv.forward_step(example_clip[:, :, 0])
+    _ = coconv.forward_step(example_clip[:, :, 1])
+    x1 = coconv.forward_step(example_clip[:, :, 2])
+    x2 = coconv.forward_step(example_clip[:, :, 3])
     output = torch.tensor([[[[[x1]], [[x2]]]]])
 
-    output_alternative = coconv.forward_regular(example_clip)
+    output_alternative = coconv.forward_steps(example_clip)
 
     assert torch.allclose(output, output_alternative)
     assert torch.allclose(output, target)
@@ -234,8 +234,8 @@ def test_forward_long_kernel():
     )
     target = conv(example_clip)
 
-    coconv = Conv3d.from_regular(conv)
-    # coconv = Conv3d(
+    coconv = co.Conv3d.from_regular(conv)
+    # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
     #     kernel_size=(T, S, S),
@@ -245,13 +245,13 @@ def test_forward_long_kernel():
     # coconv.weight = conv.weight
     # coconv.bias = conv.bias
 
-    _ = coconv(example_clip[:, :, 0])
-    _ = coconv(example_clip[:, :, 1])
-    x1 = coconv(example_clip[:, :, 2])
-    x2 = coconv(example_clip[:, :, 3])
+    _ = coconv.forward_step(example_clip[:, :, 0])
+    _ = coconv.forward_step(example_clip[:, :, 1])
+    x1 = coconv.forward_step(example_clip[:, :, 2])
+    x2 = coconv.forward_step(example_clip[:, :, 3])
     output = torch.tensor([[[[[x1]], [[x2]]]]])
 
-    output_alternative = coconv.forward_regular(example_clip)
+    output_alternative = coconv.forward_steps(example_clip)
 
     assert torch.allclose(output, output_alternative)
     assert torch.allclose(output, target)
@@ -263,18 +263,17 @@ def test_from_conv3d():
     )
     target = regular(example_clip)
 
-    co3 = Conv3d.from_regular(regular)
+    co3 = co.Conv3d.from_regular(regular)
 
     output = []
     for i in range(example_clip.shape[2]):
-        output.append(co3.forward(example_clip[:, :, i]))
+        output.append(co3.forward_step(example_clip[:, :, i]))
 
     for t in range(example_clip.shape[2] - (T - 1)):
         assert torch.allclose(target[:, :, t], output[t + (T - 1)])
 
     # Alternative: gives same output as regular version
-    output3 = co3.forward_regular(example_clip)
-
+    output3 = co3.forward_steps(example_clip)
     assert torch.allclose(output3, target)
 
 
@@ -290,7 +289,7 @@ def test_from_conv3d_bad_shape():
     )
 
     # Also warns
-    co3 = Conv3d.from_regular(regular)
+    co3 = co.Conv3d.from_regular(regular)
 
     # Changed               V
     assert co3.dilation == (1, 2, 2)
@@ -306,7 +305,7 @@ example_clip_large = torch.normal(mean=torch.zeros(2 * 2 * 4 * 8 * 8)).reshape(
 
 
 def test_complex():
-    # Take an example input and pass it thorugh a Conv3D the traditional way
+    # Take an example input and pass it thorugh a co.Conv3D the traditional way
     regular = torch.nn.Conv3d(
         in_channels=2,
         out_channels=4,
@@ -319,8 +318,8 @@ def test_complex():
     )
     regular_output = regular(example_clip_large).detach()
 
-    co3 = Conv3d.from_regular(regular, temporal_fill="zeros")
-    co3_output = co3.forward_regular(example_clip_large)
+    co3 = co.Conv3d.from_regular(regular, temporal_fill="zeros")
+    co3_output = co3.forward_steps(example_clip_large)
 
     assert torch.allclose(regular_output, co3_output, atol=5e-8)
 
@@ -334,22 +333,24 @@ def test_forward_continuation():
         padding=(1, 1, 1),
         padding_mode="zeros",
     )
-    coconv = Conv3d.from_regular(conv, temporal_fill="zeros")
+    coconv = co.Conv3d.from_regular(conv, temporal_fill="zeros")
 
     # Run batch inference and fill memory
     target1 = conv(example_clip)
-    output1 = coconv.forward_regular(example_clip)
+    output1 = coconv.forward_steps(example_clip)
     assert torch.allclose(target1, output1)
 
     # Next forward
     target2 = conv(next_example_clip)
-    output2 = coconv.forward(next_example_frame)
+    output2 = coconv.forward_step(next_example_frame)
 
     # Next-to-last frame matches
     assert torch.allclose(target2[:, :, -2], output2, atol=5e-8)
 
     # Passing in zeros gives same output
-    output3 = coconv.forward(torch.zeros_like(next_example_frame), update_state=False)
+    output3 = coconv.forward_step(
+        torch.zeros_like(next_example_frame), update_state=False
+    )
     assert torch.allclose(target2[:, :, -1], output3, atol=5e-8)
 
 
@@ -377,16 +378,20 @@ def test_stacked_impulse_response():
     )
 
     # Init continual
-    cnn = torch.nn.Sequential(
-        Conv3d.from_regular(conv1, temporal_fill="zeros"),
-        Conv3d.from_regular(conv2, temporal_fill="zeros"),
-        Conv3d.from_regular(conv2, temporal_fill="zeros"),
-    )
+    cnn = [
+        co.Conv3d.from_regular(conv1, temporal_fill="zeros"),
+        co.Conv3d.from_regular(conv2, temporal_fill="zeros"),
+        co.Conv3d.from_regular(conv2, temporal_fill="zeros"),
+    ]
 
-    cnn(ones)  # Impulse
+    # Impulse
+    for mod in cnn:
+        mod.forward_step(ones)
+
     outputs = []
     for _ in range(15):
-        outputs.append(cnn(zeros))
+        for mod in cnn:
+            mod.forward_step(zeros)
 
     same_as_last = [
         torch.equal(outputs[i], outputs[i - 1]) for i in range(1, len(outputs))
@@ -401,7 +406,7 @@ def test_stacked_impulse_response():
 
 
 def test_stacked_no_pad():
-    # Without initialisation using forward_regular, the output has no delay
+    # Without initialisation using forward_steps, the output has no delay
 
     # Init regular
     conv1 = torch.nn.Conv3d(
@@ -422,8 +427,8 @@ def test_stacked_no_pad():
     )
 
     # Init continual
-    rconv1 = Conv3d.from_regular(conv1, temporal_fill="zeros")
-    rconv2 = Conv3d.from_regular(conv2, temporal_fill="zeros")
+    coconv1 = co.Conv3d.from_regular(conv1, temporal_fill="zeros")
+    coconv2 = co.Conv3d.from_regular(conv2, temporal_fill="zeros")
 
     # Targets
     target11 = conv1(long_example_clip)
@@ -433,13 +438,13 @@ def test_stacked_no_pad():
     target22 = conv2(target21)
 
     # Test 3D mode
-    output11 = rconv1.forward_regular(long_example_clip)
-    output12 = rconv2.forward_regular(output11)
+    output11 = coconv1.forward_steps(long_example_clip)
+    output12 = coconv2.forward_steps(output11)
     torch.allclose(target12, output12, atol=5e-8)
 
     # Next 2D forward
-    output21 = rconv1.forward(next_example_frame)
-    output22 = rconv2.forward(output21)
+    output21 = coconv1.forward_step(next_example_frame)
+    output22 = coconv2.forward_step(output21)
 
     # Correct result is output
     assert torch.allclose(target22[:, :, -1], output22, atol=5e-8)

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -1,24 +1,24 @@
 import torch
-from torch.nn import Conv1d, Conv2d
+from torch import nn
 
-from continual import ConvCo1d, ConvCo2d, ConvCo3d
+from continual import Conv1d, Conv2d, Conv3d
 from continual.utils import TensorPlaceholder
 
 torch.manual_seed(42)
 
 
-def test_ConvCo1d():
+def test_Conv1d():
     C = 2
     T = 3
     L = 5
     sample = torch.normal(mean=torch.zeros(L * C)).reshape((1, C, L))
 
     # Regular
-    conv = Conv1d(in_channels=C, out_channels=1, kernel_size=T, bias=True)
+    conv = nn.Conv1d(in_channels=C, out_channels=1, kernel_size=T, bias=True)
     target = conv(sample)
 
     # Continual
-    co_conv = ConvCo1d.from_regular(conv, "zeros")
+    co_conv = Conv1d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -38,7 +38,7 @@ def test_ConvCo1d():
     assert torch.equal(target, output2)
 
 
-def test_ConvCo1d_stride():
+def test_Conv1d_stride():
     C = 2
     T = 3
     L = 5
@@ -46,11 +46,11 @@ def test_ConvCo1d_stride():
     sample = torch.normal(mean=torch.zeros(L * C)).reshape((1, C, L))
 
     # Regular
-    conv = Conv1d(in_channels=C, out_channels=1, kernel_size=T, bias=True, stride=S)
+    conv = nn.Conv1d(in_channels=C, out_channels=1, kernel_size=T, bias=True, stride=S)
     target = conv(sample)
 
     # Continual
-    co_conv = ConvCo1d.from_regular(conv, "zeros")
+    co_conv = Conv1d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -69,7 +69,7 @@ def test_ConvCo1d_stride():
     assert torch.allclose(target, output)
 
 
-def test_ConvCo2d():
+def test_Conv2d():
     C = 2
     T = 3
     S = 2
@@ -78,11 +78,11 @@ def test_ConvCo2d():
     sample = torch.normal(mean=torch.zeros(L * C * H)).reshape((1, C, L, H))
 
     # Regular
-    conv = Conv2d(in_channels=C, out_channels=1, kernel_size=(T, S), bias=True)
+    conv = nn.Conv2d(in_channels=C, out_channels=1, kernel_size=(T, S), bias=True)
     target = conv(sample)
 
     # Continual
-    co_conv = ConvCo2d.from_regular(conv, "zeros")
+    co_conv = Conv2d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -102,7 +102,7 @@ def test_ConvCo2d():
     assert torch.equal(target, output2)
 
 
-def test_ConvCo2d_stride():
+def test_Conv2d_stride():
     C = 2
     T = 3
     S = 2
@@ -112,13 +112,13 @@ def test_ConvCo2d_stride():
     sample = torch.normal(mean=torch.zeros(L * C * H)).reshape((1, C, L, H))
 
     # Regular
-    conv = Conv2d(
+    conv = nn.Conv2d(
         in_channels=C, out_channels=1, kernel_size=(T, S), bias=True, stride=stride
     )
     target = conv(sample)
 
     # Continual
-    co_conv = ConvCo2d.from_regular(conv, "zeros")
+    co_conv = Conv2d.from_regular(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -205,8 +205,8 @@ def test_basic_forward():
     )
     target = conv(example_clip)
 
-    coconv = ConvCo3d.from_regular(conv)
-    # coconv = ConvCo3d(
+    coconv = Conv3d.from_regular(conv)
+    # coconv = Conv3d(
     #     in_channels=1,
     #     out_channels=1,
     #     kernel_size=(S, T, T),
@@ -234,8 +234,8 @@ def test_forward_long_kernel():
     )
     target = conv(example_clip)
 
-    coconv = ConvCo3d.from_regular(conv)
-    # coconv = ConvCo3d(
+    coconv = Conv3d.from_regular(conv)
+    # coconv = Conv3d(
     #     in_channels=1,
     #     out_channels=1,
     #     kernel_size=(T, S, S),
@@ -263,7 +263,7 @@ def test_from_conv3d():
     )
     target = regular(example_clip)
 
-    co3 = ConvCo3d.from_regular(regular)
+    co3 = Conv3d.from_regular(regular)
 
     output = []
     for i in range(example_clip.shape[2]):
@@ -290,7 +290,7 @@ def test_from_conv3d_bad_shape():
     )
 
     # Also warns
-    co3 = ConvCo3d.from_regular(regular)
+    co3 = Conv3d.from_regular(regular)
 
     # Changed               V
     assert co3.dilation == (1, 2, 2)
@@ -319,7 +319,7 @@ def test_complex():
     )
     regular_output = regular(example_clip_large).detach()
 
-    co3 = ConvCo3d.from_regular(regular, temporal_fill="zeros")
+    co3 = Conv3d.from_regular(regular, temporal_fill="zeros")
     co3_output = co3.forward_regular(example_clip_large)
 
     assert torch.allclose(regular_output, co3_output, atol=5e-8)
@@ -334,7 +334,7 @@ def test_forward_continuation():
         padding=(1, 1, 1),
         padding_mode="zeros",
     )
-    coconv = ConvCo3d.from_regular(conv, temporal_fill="zeros")
+    coconv = Conv3d.from_regular(conv, temporal_fill="zeros")
 
     # Run batch inference and fill memory
     target1 = conv(example_clip)
@@ -378,9 +378,9 @@ def test_stacked_impulse_response():
 
     # Init continual
     cnn = torch.nn.Sequential(
-        ConvCo3d.from_regular(conv1, temporal_fill="zeros"),
-        ConvCo3d.from_regular(conv2, temporal_fill="zeros"),
-        ConvCo3d.from_regular(conv2, temporal_fill="zeros"),
+        Conv3d.from_regular(conv1, temporal_fill="zeros"),
+        Conv3d.from_regular(conv2, temporal_fill="zeros"),
+        Conv3d.from_regular(conv2, temporal_fill="zeros"),
     )
 
     cnn(ones)  # Impulse
@@ -422,8 +422,8 @@ def test_stacked_no_pad():
     )
 
     # Init continual
-    rconv1 = ConvCo3d.from_regular(conv1, temporal_fill="zeros")
-    rconv2 = ConvCo3d.from_regular(conv2, temporal_fill="zeros")
+    rconv1 = Conv3d.from_regular(conv1, temporal_fill="zeros")
+    rconv2 = Conv3d.from_regular(conv2, temporal_fill="zeros")
 
     # Targets
     target11 = conv1(long_example_clip)

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -18,7 +18,7 @@ def test_Conv1d():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv1d.from_regular(conv, "zeros")
+    co_conv = co.Conv1d.like(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -50,7 +50,7 @@ def test_Conv1d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv1d.from_regular(conv, "zeros")
+    co_conv = co.Conv1d.like(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -82,7 +82,7 @@ def test_Conv2d():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv2d.from_regular(conv, "zeros")
+    co_conv = co.Conv2d.like(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -118,7 +118,7 @@ def test_Conv2d_stride():
     target = conv(sample)
 
     # Continual
-    co_conv = co.Conv2d.from_regular(conv, "zeros")
+    co_conv = co.Conv2d.like(conv, "zeros")
     output = []
 
     # Frame by frame
@@ -205,7 +205,7 @@ def test_basic_forward():
     )
     target = conv(example_clip)
 
-    coconv = co.Conv3d.from_regular(conv)
+    coconv = co.Conv3d.like(conv)
     # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
@@ -234,7 +234,7 @@ def test_forward_long_kernel():
     )
     target = conv(example_clip)
 
-    coconv = co.Conv3d.from_regular(conv)
+    coconv = co.Conv3d.like(conv)
     # coconv = co.Conv3d(
     #     in_channels=1,
     #     out_channels=1,
@@ -263,7 +263,7 @@ def test_from_conv3d():
     )
     target = regular(example_clip)
 
-    co3 = co.Conv3d.from_regular(regular)
+    co3 = co.Conv3d.like(regular)
 
     output = []
     for i in range(example_clip.shape[2]):
@@ -289,7 +289,7 @@ def test_from_conv3d_bad_shape():
     )
 
     # Also warns
-    co3 = co.Conv3d.from_regular(regular)
+    co3 = co.Conv3d.like(regular)
 
     # Changed               V
     assert co3.dilation == (1, 2, 2)
@@ -318,7 +318,7 @@ def test_complex():
     )
     regular_output = regular(example_clip_large).detach()
 
-    co3 = co.Conv3d.from_regular(regular, temporal_fill="zeros")
+    co3 = co.Conv3d.like(regular, temporal_fill="zeros")
     co3_output = co3.forward_steps(example_clip_large)
 
     assert torch.allclose(regular_output, co3_output, atol=5e-8)
@@ -333,7 +333,7 @@ def test_forward_continuation():
         padding=(1, 1, 1),
         padding_mode="zeros",
     )
-    coconv = co.Conv3d.from_regular(conv, temporal_fill="zeros")
+    coconv = co.Conv3d.like(conv, temporal_fill="zeros")
 
     # Run batch inference and fill memory
     target1 = conv(example_clip)
@@ -379,9 +379,9 @@ def test_stacked_impulse_response():
 
     # Init continual
     cnn = [
-        co.Conv3d.from_regular(conv1, temporal_fill="zeros"),
-        co.Conv3d.from_regular(conv2, temporal_fill="zeros"),
-        co.Conv3d.from_regular(conv2, temporal_fill="zeros"),
+        co.Conv3d.like(conv1, temporal_fill="zeros"),
+        co.Conv3d.like(conv2, temporal_fill="zeros"),
+        co.Conv3d.like(conv2, temporal_fill="zeros"),
     ]
 
     # Impulse
@@ -427,8 +427,8 @@ def test_stacked_no_pad():
     )
 
     # Init continual
-    coconv1 = co.Conv3d.from_regular(conv1, temporal_fill="zeros")
-    coconv2 = co.Conv3d.from_regular(conv2, temporal_fill="zeros")
+    coconv1 = co.Conv3d.like(conv1, temporal_fill="zeros")
+    coconv2 = co.Conv3d.like(conv2, temporal_fill="zeros")
 
     # Targets
     target11 = conv1(long_example_clip)

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -128,13 +128,15 @@ def test_Conv2d_stride():
     # Match after delay of T - 1
     for t in range(sample.shape[2] - (T - 1)):
         if t % S == 0:
-            assert torch.allclose(target[:, :, t // stride], output[t + (T - 1)])
+            assert torch.allclose(
+                target[:, :, t // stride], output[t + (T - 1)], atol=1e-7
+            )
         else:
             assert type(output[t + (T - 1)]) is TensorPlaceholder
 
     # Whole time-series
     output = co_conv.forward_steps(sample)
-    assert torch.allclose(target, output)
+    assert torch.allclose(target, output, atol=1e-7)
 
 
 T = S = 3
@@ -345,13 +347,13 @@ def test_forward_continuation():
     output2 = coconv.forward_step(next_example_frame)
 
     # Next-to-last frame matches
-    assert torch.allclose(target2[:, :, -2], output2, atol=5e-8)
+    assert torch.allclose(target2[:, :, -2], output2, atol=1e-7)
 
     # Passing in zeros gives same output
     output3 = coconv.forward_step(
         torch.zeros_like(next_example_frame), update_state=False
     )
-    assert torch.allclose(target2[:, :, -1], output3, atol=5e-8)
+    assert torch.allclose(target2[:, :, -1], output3, atol=1e-7)
 
 
 def test_stacked_impulse_response():

--- a/tests/continual/test_delay.py
+++ b/tests/continual/test_delay.py
@@ -56,3 +56,30 @@ def test_delay_2d():
     assert torch.equal(delay.forward_step(ones), example_input[:, :, 3])
 
     assert torch.equal(delay.forward_step(ones), ones)
+
+
+def test_state():
+    example_input = torch.rand((2, 2, 4, 3))
+    delay = Delay(delay=2, temporal_fill="zeros")
+
+    # State stays clean
+    assert getattr(delay, "state_buffer", None) is None
+    assert getattr(delay, "state_index", None) is None
+
+    delay.forward(example_input)
+
+    assert getattr(delay, "state_buffer", None) is None
+    assert getattr(delay, "state_index", None) is None
+
+    # State is populated
+    delay.forward_steps(example_input)
+
+    assert torch.equal(delay.state_buffer[1], example_input[:, :, 1])
+    assert torch.equal(delay.state_buffer[0], example_input[:, :, 2])
+    assert delay.state_index == 1
+
+    # State can be cleaned
+    delay.clean_state()
+
+    assert getattr(delay, "state_buffer", None) is None
+    assert getattr(delay, "state_index", None) is None

--- a/tests/continual/test_delay.py
+++ b/tests/continual/test_delay.py
@@ -12,19 +12,23 @@ def test_delay_3d():
     zeros = torch.zeros_like(example_input[:, :, 0])
     ones = torch.ones_like(example_input[:, :, 0])
 
-    assert torch.equal(delay(example_input[:, :, 0]), zeros)
+    assert torch.equal(delay.forward_step(example_input[:, :, 0]), zeros)
 
-    assert torch.equal(delay(example_input[:, :, 1]), zeros)
+    assert torch.equal(delay.forward_step(example_input[:, :, 1]), zeros)
 
-    assert torch.equal(delay(example_input[:, :, 2]), example_input[:, :, 0])
+    assert torch.equal(
+        delay.forward_step(example_input[:, :, 2]), example_input[:, :, 0]
+    )
 
-    assert torch.equal(delay(example_input[:, :, 3]), example_input[:, :, 1])
+    assert torch.equal(
+        delay.forward_step(example_input[:, :, 3]), example_input[:, :, 1]
+    )
 
-    assert torch.equal(delay(ones), example_input[:, :, 2])
+    assert torch.equal(delay.forward_step(ones), example_input[:, :, 2])
 
-    assert torch.equal(delay(ones), example_input[:, :, 3])
+    assert torch.equal(delay.forward_step(ones), example_input[:, :, 3])
 
-    assert torch.equal(delay(ones), ones)
+    assert torch.equal(delay.forward_step(ones), ones)
 
 
 def test_delay_2d():
@@ -35,16 +39,20 @@ def test_delay_2d():
     zeros = torch.zeros_like(example_input[:, :, 0])
     ones = torch.ones_like(example_input[:, :, 0])
 
-    assert torch.equal(delay(example_input[:, :, 0]), zeros)
+    assert torch.equal(delay.forward_step(example_input[:, :, 0]), zeros)
 
-    assert torch.equal(delay(example_input[:, :, 1]), zeros)
+    assert torch.equal(delay.forward_step(example_input[:, :, 1]), zeros)
 
-    assert torch.equal(delay(example_input[:, :, 2]), example_input[:, :, 0])
+    assert torch.equal(
+        delay.forward_step(example_input[:, :, 2]), example_input[:, :, 0]
+    )
 
-    assert torch.equal(delay(example_input[:, :, 3]), example_input[:, :, 1])
+    assert torch.equal(
+        delay.forward_step(example_input[:, :, 3]), example_input[:, :, 1]
+    )
 
-    assert torch.equal(delay(ones), example_input[:, :, 2])
+    assert torch.equal(delay.forward_step(ones), example_input[:, :, 2])
 
-    assert torch.equal(delay(ones), example_input[:, :, 3])
+    assert torch.equal(delay.forward_step(ones), example_input[:, :, 3])
 
-    assert torch.equal(delay(ones), ones)
+    assert torch.equal(delay.forward_step(ones), ones)

--- a/tests/continual/test_delay.py
+++ b/tests/continual/test_delay.py
@@ -74,9 +74,9 @@ def test_state():
     # State is populated
     delay.forward_steps(example_input)
 
-    assert torch.equal(delay.state_buffer[1], example_input[:, :, 1])
     assert torch.equal(delay.state_buffer[0], example_input[:, :, 2])
-    assert delay.state_index == 1
+    assert torch.equal(delay.state_buffer[1], example_input[:, :, 3])
+    assert delay.state_index == 0
 
     # State can be cleaned
     delay.clean_state()

--- a/tests/continual/test_example.py
+++ b/tests/continual/test_example.py
@@ -1,5 +1,6 @@
 import torch
 from torch import nn
+
 import continual as co
 
 

--- a/tests/continual/test_example.py
+++ b/tests/continual/test_example.py
@@ -1,0 +1,23 @@
+import torch
+from torch import nn
+import continual as co
+
+
+def test_readme_example():  # B, C, T, H, W
+    example = torch.normal(mean=torch.zeros(5 * 3 * 3)).reshape((1, 1, 5, 3, 3))
+
+    # Acts as a drop-in replacement for torch.nn modules ✅
+    co_conv = co.Conv3d(in_channels=1, out_channels=1, kernel_size=(3, 3, 3))
+    nn_conv = nn.Conv3d(in_channels=1, out_channels=1, kernel_size=(3, 3, 3))
+    co_conv.load_state_dict(nn_conv.state_dict())
+
+    co_output = co_conv(example)  # Same exact computation
+    nn_output = nn_conv(example)  # Same exact computation
+    assert torch.equal(co_output, nn_output)
+
+    # But can also perform online inference efficiently 🚀
+    firsts = co_conv.forward_steps(example[:, :, :4])
+    last = co_conv.forward_step(example[:, :, 4])
+
+    assert torch.allclose(nn_output[:, :, : co_conv.delay], firsts)
+    assert torch.allclose(nn_output[:, :, co_conv.delay], last)

--- a/tests/continual/test_pool.py
+++ b/tests/continual/test_pool.py
@@ -24,7 +24,7 @@ def test_AvgPool1d():
     target = pool(sample)
 
     # Continual
-    co_pool = AvgPool1d(T)
+    co_pool = AvgPool1d.build_from(pool)
     output = []
 
     # Frame by frame
@@ -55,7 +55,7 @@ def test_AdaptiveAvgPool2d():
     target = pool(sample)
 
     # Continual
-    co_pool = AdaptiveAvgPool2d(window_size=L, output_size=(1,))
+    co_pool = AdaptiveAvgPool2d(temporal_kernel_size=L, output_size=(1,))
 
     # Whole time-series
     output = co_pool.forward_steps(sample)
@@ -81,7 +81,9 @@ next_example_clip = torch.stack(
 
 def test_AvgPool3d():
     target = nn.AvgPool3d((2, 2, 2))(example_clip)
-    output = AvgPool3d(window_size=2, kernel_size=(2, 2)).forward_steps(example_clip)
+    output = AvgPool3d(temporal_kernel_size=2, kernel_size=(2, 2)).forward_steps(
+        example_clip
+    )
     sub_output = torch.stack(
         [
             output[:, :, 0],
@@ -94,7 +96,7 @@ def test_AvgPool3d():
 
 def test_AdaptiveAvgPool3d():
     pool = nn.AdaptiveAvgPool3d((1, 1, 1))
-    copool = AdaptiveAvgPool3d(window_size=4, output_size=(1, 1))
+    copool = AdaptiveAvgPool3d(temporal_kernel_size=4, output_size=(1, 1))
 
     target = pool(example_clip)
     output = copool.forward_steps(example_clip)
@@ -108,7 +110,9 @@ def test_AdaptiveAvgPool3d():
 
 def test_MaxPool3d():
     target = nn.MaxPool3d((2, 2, 2))(example_clip)
-    output = MaxPool3d(window_size=2, kernel_size=(2, 2)).forward_steps(example_clip)
+    output = MaxPool3d(temporal_kernel_size=2, kernel_size=(2, 2)).forward_steps(
+        example_clip
+    )
     sub_output = torch.stack(
         [
             output[:, :, 0],
@@ -121,15 +125,15 @@ def test_MaxPool3d():
 
 def test_AdaptiveMaxPool3d():
     target = nn.AdaptiveMaxPool3d((1, 1, 1))(example_clip)
-    output = AdaptiveMaxPool3d(window_size=4, output_size=(1, 1)).forward_steps(
-        example_clip
-    )
+    output = AdaptiveMaxPool3d(
+        temporal_kernel_size=4, output_size=(1, 1)
+    ).forward_steps(example_clip)
     assert torch.allclose(output, target)
 
 
 def test_MaxPool3d_dilation():
     target = nn.MaxPool3d((2, 2, 2), dilation=(2, 1, 1))(example_long)
     output = MaxPool3d(
-        window_size=4, kernel_size=(2, 2), temporal_dilation=2
+        temporal_kernel_size=4, kernel_size=(2, 2), temporal_dilation=2
     ).forward_steps(example_long)
     assert torch.allclose(target, output.index_select(2, torch.tensor([0, 2, 4])))

--- a/tests/continual/test_pool.py
+++ b/tests/continual/test_pool.py
@@ -1,5 +1,7 @@
 import torch
-from torch.nn.modules.pooling import (
+from torch import nn
+
+from continual import (
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,
     AdaptiveMaxPool3d,
@@ -8,30 +10,21 @@ from torch.nn.modules.pooling import (
     MaxPool3d,
 )
 
-from continual import (
-    AdaptiveAvgPoolCo2d,
-    AdaptiveAvgPoolCo3d,
-    AdaptiveMaxPoolCo3d,
-    AvgPoolCo1d,
-    AvgPoolCo3d,
-    MaxPoolCo3d,
-)
-
 torch.manual_seed(42)
 
 
-def test_AvgPoolCo1d():
+def test_AvgPool1d():
     C = 2
     T = 3
     L = 5
     sample = torch.normal(mean=torch.zeros(L * C)).reshape((1, C, L))
 
     # Regular
-    pool = AvgPool1d(T, stride=1)
+    pool = nn.AvgPool1d(T, stride=1)
     target = pool(sample)
 
     # Continual
-    co_pool = AvgPoolCo1d(T)
+    co_pool = AvgPool1d(T)
     output = []
 
     # Frame by frame
@@ -51,18 +44,18 @@ def test_AvgPoolCo1d():
     assert torch.equal(target, output2)
 
 
-def test_AdaptiveAvgPoolCo2d():
+def test_AdaptiveAvgPool2d():
     C = 2
     L = 5
     S = 3
     sample = torch.normal(mean=torch.zeros(L * C * S)).reshape((1, C, L, S))
 
     # Regular
-    pool = AdaptiveAvgPool2d((1, 1))
+    pool = nn.AdaptiveAvgPool2d((1, 1))
     target = pool(sample)
 
     # Continual
-    co_pool = AdaptiveAvgPoolCo2d(window_size=L, output_size=(1,))
+    co_pool = AdaptiveAvgPool2d(window_size=L, output_size=(1,))
 
     # Whole time-series
     output = co_pool.forward_regular(sample)
@@ -86,11 +79,9 @@ next_example_clip = torch.stack(
 )
 
 
-def test_AvgPoolCo3d():
-    target = AvgPool3d((2, 2, 2))(example_clip)
-    output = AvgPoolCo3d(window_size=2, kernel_size=(2, 2)).forward_regular(
-        example_clip
-    )
+def test_AvgPool3d():
+    target = nn.AvgPool3d((2, 2, 2))(example_clip)
+    output = AvgPool3d(window_size=2, kernel_size=(2, 2)).forward_regular(example_clip)
     sub_output = torch.stack(
         [
             output[:, :, 0],
@@ -101,9 +92,9 @@ def test_AvgPoolCo3d():
     assert torch.allclose(sub_output, target)
 
 
-def test_AdaptiveAvgPoolCo3d():
-    pool = AdaptiveAvgPool3d((1, 1, 1))
-    rpool = AdaptiveAvgPoolCo3d(window_size=4, output_size=(1, 1))
+def test_AdaptiveAvgPool3d():
+    pool = nn.AdaptiveAvgPool3d((1, 1, 1))
+    rpool = AdaptiveAvgPool3d(window_size=4, output_size=(1, 1))
 
     target = pool(example_clip)
     output = rpool.forward_regular(example_clip)
@@ -115,11 +106,9 @@ def test_AdaptiveAvgPoolCo3d():
     assert torch.allclose(target_next, output_frame_next)
 
 
-def test_MaxPoolCo3d():
-    target = MaxPool3d((2, 2, 2))(example_clip)
-    output = MaxPoolCo3d(window_size=2, kernel_size=(2, 2)).forward_regular(
-        example_clip
-    )
+def test_MaxPool3d():
+    target = nn.MaxPool3d((2, 2, 2))(example_clip)
+    output = MaxPool3d(window_size=2, kernel_size=(2, 2)).forward_regular(example_clip)
     sub_output = torch.stack(
         [
             output[:, :, 0],
@@ -130,17 +119,17 @@ def test_MaxPoolCo3d():
     assert torch.allclose(sub_output, target)
 
 
-def test_AdaptiveMaxPoolCo3d():
-    target = AdaptiveMaxPool3d((1, 1, 1))(example_clip)
-    output = AdaptiveMaxPoolCo3d(window_size=4, output_size=(1, 1)).forward_regular(
+def test_AdaptiveMaxPool3d():
+    target = nn.AdaptiveMaxPool3d((1, 1, 1))(example_clip)
+    output = AdaptiveMaxPool3d(window_size=4, output_size=(1, 1)).forward_regular(
         example_clip
     )
     assert torch.allclose(output, target)
 
 
-def test_MaxPoolCo3d_dilation():
-    target = MaxPool3d((2, 2, 2), dilation=(2, 1, 1))(example_long)
-    output = MaxPoolCo3d(
+def test_MaxPool3d_dilation():
+    target = nn.MaxPool3d((2, 2, 2), dilation=(2, 1, 1))(example_long)
+    output = MaxPool3d(
         window_size=4, kernel_size=(2, 2), temporal_dilation=2
     ).forward_regular(example_long)
     assert torch.allclose(target, output.index_select(2, torch.tensor([0, 2, 4])))


### PR DESCRIPTION
## Changed
- Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
- Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
- Bumped version to 0.2.0