### PR TITLE
Flattened state_dict export and import

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## Added
+- Flattened state dict export and loading via a `flatten` argument. This feature improves interoperability complex modules, that were not originally constructed with the `co.Sequential` and `co.Parallel` building blocks.
+- Context manager for triggering flattened state_dict export and loading.
 
 
 ## [0.5.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.0]
 ## Added
 - Flattened state dict export and loading via a `flatten` argument. This feature improves interoperability complex modules, that were not originally constructed with the `co.Sequential` and `co.Parallel` building blocks.
 - Context manager for triggering flattened state_dict export and loading.

--- a/README.md
+++ b/README.md
@@ -263,9 +263,6 @@ In addition, we support interoperability with a wide range of modules from `torc
 </div>
 
 ```python3
-import continual as co
-from torch import nn
-
 mb_conv = co.Residual(
     co.Sequential(
       co.Conv3d(32, 64, kernel_size=(1, 1, 1)),
@@ -288,9 +285,6 @@ mb_conv = co.Residual(
 </div>
 
 ```python3
-import continual as co
-from torch import nn
-
 def norm_relu(module, channels):
     return co.Sequential(
         module,

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ inception_module = co.Parallel(
 ```
 
 
-## Continual 3D [Squeeze-and-Excitation module](https://arxiv.org/pdf/1709.01507.pdf)
+### Continual 3D [Squeeze-and-Excitation module](https://arxiv.org/pdf/1709.01507.pdf)
 
 <div align="center">
   <img src="https://raw.githubusercontent.com/LukasHedegaard/continual-inference/main/figures/examples/se_block.png" width="230">

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -16,3 +16,4 @@ from .pooling import (  # noqa: F401
     MaxPool3d,
 )
 from .ptflops import _register_ptflops  # noqa: F401
+from .utils import flat_state_dict  # noqa: F401

--- a/continual/container.py
+++ b/continual/container.py
@@ -28,9 +28,9 @@ class FlattenableStateDict:
         self, destination=None, prefix="", keep_vars=False, flatten=False
     ) -> OrderedDict[str, Tensor]:
         d = nn.Module.state_dict(self, destination, prefix, keep_vars)
-        from continual.utils import _FLATTEN_STATE_DICT
+        from continual.utils import flat_state_dict
 
-        if flatten or _FLATTEN_STATE_DICT:
+        if flatten or flat_state_dict.flatten:
             flat_keys = [
                 ".".join(part for part in name.split(".") if not part.isdigit())
                 for name in list(d.keys())
@@ -46,9 +46,9 @@ class FlattenableStateDict:
         strict: bool = True,
         flatten=False,
     ):
-        from continual.utils import _FLATTEN_STATE_DICT
+        from continual.utils import flat_state_dict
 
-        if flatten or _FLATTEN_STATE_DICT:
+        if flatten or flat_state_dict.flatten:
             long_keys = nn.Module.state_dict(self, keep_vars=True).keys()
             short2long = {
                 ".".join(part for part in key.split(".") if not part.isdigit()): key

--- a/continual/container.py
+++ b/continual/container.py
@@ -1,7 +1,7 @@
-from collections import OrderedDict
+import collections
 from enum import Enum
 from functools import reduce
-from typing import Callable, Optional, Sequence, Tuple, Union, overload
+from typing import Callable, Optional, OrderedDict, Sequence, Tuple, Union, overload
 
 import torch
 from torch import Tensor, nn
@@ -36,7 +36,7 @@ class FlattenableStateDict:
                 for name in list(d.keys())
             ]
             if len(set(flat_keys)) == len(d.keys()):
-                d = OrderedDict(list(zip(flat_keys, d.values())))
+                d = collections.OrderedDict(list(zip(flat_keys, d.values())))
 
         return d
 
@@ -54,7 +54,7 @@ class FlattenableStateDict:
                 ".".join(part for part in key.split(".") if not part.isdigit()): key
                 for key in list(long_keys)
             }
-            state_dict = OrderedDict(
+            state_dict = collections.OrderedDict(
                 [(short2long[key], val) for key, val in state_dict.items()]
             )
 
@@ -116,7 +116,9 @@ class Sequential(FlattenableStateDict, nn.Sequential, Padded, CoModule):
         from .convert import continual  # import here due to circular import
 
         return Sequential(
-            OrderedDict([(k, continual(m)) for k, m in module._modules.items()])
+            collections.OrderedDict(
+                [(k, continual(m)) for k, m in module._modules.items()]
+            )
         )
 
     def clean_state(self):
@@ -332,7 +334,7 @@ def Residual(
     aggregation_fn: Aggregation = "sum",
 ):
     return Parallel(
-        OrderedDict(
+        collections.OrderedDict(
             [
                 (  # Residual first yields easier broadcasting in aggregation functions
                     "residual",

--- a/continual/container.py
+++ b/continual/container.py
@@ -1,7 +1,7 @@
-import collections
+from collections import OrderedDict
 from enum import Enum
 from functools import reduce
-from typing import Callable, Optional, OrderedDict, Sequence, Tuple, Union, overload
+from typing import Callable, Optional, Sequence, Tuple, Union, overload
 
 import torch
 from torch import Tensor, nn
@@ -26,7 +26,7 @@ class FlattenableStateDict:
 
     def state_dict(
         self, destination=None, prefix="", keep_vars=False, flatten=False
-    ) -> OrderedDict[str, Tensor]:
+    ) -> "OrderedDict[str, Tensor]":
         d = nn.Module.state_dict(self, destination, prefix, keep_vars)
         from continual.utils import flat_state_dict
 
@@ -36,13 +36,13 @@ class FlattenableStateDict:
                 for name in list(d.keys())
             ]
             if len(set(flat_keys)) == len(d.keys()):
-                d = collections.OrderedDict(list(zip(flat_keys, d.values())))
+                d = OrderedDict(list(zip(flat_keys, d.values())))
 
         return d
 
     def load_state_dict(
         self,
-        state_dict: OrderedDict[str, Tensor],
+        state_dict: "OrderedDict[str, Tensor]",
         strict: bool = True,
         flatten=False,
     ):
@@ -54,7 +54,7 @@ class FlattenableStateDict:
                 ".".join(part for part in key.split(".") if not part.isdigit()): key
                 for key in list(long_keys)
             }
-            state_dict = collections.OrderedDict(
+            state_dict = OrderedDict(
                 [(short2long[key], val) for key, val in state_dict.items()]
             )
 
@@ -116,9 +116,7 @@ class Sequential(FlattenableStateDict, nn.Sequential, Padded, CoModule):
         from .convert import continual  # import here due to circular import
 
         return Sequential(
-            collections.OrderedDict(
-                [(k, continual(m)) for k, m in module._modules.items()]
-            )
+            OrderedDict([(k, continual(m)) for k, m in module._modules.items()])
         )
 
     def clean_state(self):
@@ -334,7 +332,7 @@ def Residual(
     aggregation_fn: Aggregation = "sum",
 ):
     return Parallel(
-        collections.OrderedDict(
+        OrderedDict(
             [
                 (  # Residual first yields easier broadcasting in aggregation functions
                     "residual",

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -20,3 +20,22 @@ def rgetattr(obj, attr, *args):
         return getattr(obj, attr, *args)
 
     return reduce(_getattr, [obj] + attr.split("."))
+
+
+_FLATTEN_STATE_DICT: bool = False
+
+
+class flat_state_dict(object):
+    r"""Context-manager that flattens the state dict of containers.
+
+    If a container module was not explicitely named by means of an OrderedDict,
+    it will attempt to flatten the keys during both the `state_dict` and `load_state_dict` operations.
+    """
+
+    def __enter__(self):
+        global _FLATTEN_STATE_DICT
+        _FLATTEN_STATE_DICT = True
+
+    def __exit__(self, *args, **kwargs):
+        global _FLATTEN_STATE_DICT
+        _FLATTEN_STATE_DICT = False

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.5.0",
+    version="0.6.0",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -238,7 +238,7 @@ def test_flat_state_dict():
     assert torch.equal(nested[1].c1.bias, nested_new[1].c1.bias)
 
     # >> Part 3: Test context manager
-    with co.utils.flat_state_dict():
+    with co.utils.flat_state_dict:
         # Export works as above despite `flatten=False`
         sd_flat2 = nested.state_dict(flatten=False)
         assert sd_flat.keys() == sd_flat2.keys()


### PR DESCRIPTION
## Added
- Flattened state dict export and loading via a `flatten` argument. This feature improves interoperability complex modules, that were not originally constructed with the `co.Sequential` and `co.Parallel` building blocks.
- Context manager for triggering flattened state_dict export and loading.
