### PR TITLE
Updates forward_step(s) interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Independent state_dict and load_state_dict functions.
 - Added nonempty check for aggregation functions in Parallel.
+- `update_state` argument to all `forward_step(s)` methods.
 
 ### Changed
 - Changed default pad_end value to False.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,12 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Independent state_dict and load_state_dict functions.
 - Added nonempty check for aggregation functions in Parallel.
 - `update_state` argument to all `forward_step(s)` methods.
+- Additional tests for edge-cases
 
 ### Changed
 - Changed default pad_end value to False.
 
 ### Fixed
 - Continual interface and conversion to support both class and module.
+- Replicate padding in `co._ConvNd`
 
 ## [0.6.1]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,85 +5,94 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Independent state_dict and load_state_dict functions.
+- Added nonempty check for aggregation functions in Parallel.
+
+### Changed
+- Changed default pad_end value to False.
+
+### Fixed
+- Continual interface and conversion to support both class and module.
 
 ## [0.6.1]
-## Changed
+### Changed
 - `co.Residual` modules to be unnamed. This allows the module state dicts to be flattened.
 
 ## [0.6.0]
-## Added
+### Added
 - Flattened state dict export and loading via a `flatten` argument. This feature improves interoperability complex modules, that were not originally constructed with the `co.Sequential` and `co.Parallel` building blocks.
 - Context manager for triggering flattened state_dict export and loading.
 
 
 ## [0.5.0]
-## Added
+### Added
 - Support for zero-delay in `co.Delay`
 - Support for broadcasting in `co.Parallel`
 - Mul (hadamark product) aggregation in `co.Parallel`
 - Example of Squeeze and Excitation block
 
-## Changed
+### Changed
 - `co._PoolNd` attribute naming: "temporal_" removed as prefix for kernel_size, stride, dilation, and padding.
 
 
 ## [0.4.0]
-## Added
+### Added
 - `co.Delay` handling for padding.
 - Handling of initialisation and strides in containers
 
-## Changed
+### Changed
 - `co.Conv` `build_from` behavior to not change dilation and stride. Argument overload supported instead. 
 - `pad_start` and `pad_end` args to convolution and pooling modules `forward_steps`.
 - Behavior of modules while they initialise. Now, a TensorPlaceholder is passed for initialising steps.
 
-## Removed
+### Removed
 - Automatic unsqueeze in pooling.
 
 
 ## [0.3.1]
-## Added
+### Added
 - Support for dropout.
 
 
 ## [0.3.0]
-## Added
+### Added
 - Support for dilation and stride in pooling.
 
-## Changed
+### Changed
 - Pooling API to match torch.nn better.
 - `_ConvCoNd.forward_steps` doesn't invoke `clean_state` anymore.
 
 
 ## [0.2.2]
-## Added
+### Added
 - Automatic conversion of batch normalisation and activation functions.
 
-## Fixed
+### Fixed
 - Separate dilation and stride in pool.
 
-## Changed
+### Changed
 - Conv forward to use temporal padding like (like nn.Conv).
 
-## Removed
+### Removed
 - `co.BatchNorm2d`
 
 ## [0.2.1]
-## Changed
+### Changed
 - Renamed `unsqueezed` to `forward_stepping`.
 
-## Removed 
+### Removed 
 - Unused utility `Zeros`
 
 
 ## [0.2.0]
-## Changed
+### Changed
 - Naming to match `torch.nn`. This lets the continual modules be used as drop-in replacements for `torch.nn` modules.
 - Renamed `forward_regular_unrolled` to `forward`, `forward_regular` to `forward_steps`, and `forward` for `forward_step`.
 - Renamed `from_regular` to `build_from`.
 - Renamed `continual` to `unsqueezed`.
 
-## Added
+### Added
 - `Sequential` wrapper for sequential application of modules
 - `Parallel` wrapper for parallel application and aggregation of inputs
 - `Residual` wrapper for adding a unity residual to a module

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [0.6.2]
 ### Added
 - Independent state_dict and load_state_dict functions.
 - Added nonempty check for aggregation functions in Parallel.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.6.2]
+## [0.7.0]
 ### Added
 - Independent state_dict and load_state_dict functions.
 - Added nonempty check for aggregation functions in Parallel.

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -16,4 +16,4 @@ from .pooling import (  # noqa: F401
     MaxPool3d,
 )
 from .ptflops import _register_ptflops  # noqa: F401
-from .utils import flat_state_dict  # noqa: F401
+from .utils import flat_state_dict, load_state_dict, state_dict  # noqa: F401

--- a/continual/container.py
+++ b/continual/container.py
@@ -271,7 +271,7 @@ class Parallel(FlattenableStateDict, nn.Sequential, Padded, CoModule):
                     break
             return TensorPlaceholder(shape)
 
-    # FIXME: There seems to be a bug hidden here
+    # NB: There seems to be a bug hidden here
     def forward_steps(self, input: Tensor, pad_end=False, update_state=True) -> Tensor:
         outs = []
         for m in self:

--- a/continual/container.py
+++ b/continual/container.py
@@ -59,8 +59,6 @@ class Sequential(FlattenableStateDict, nn.Sequential, Padded, CoModule):
     def forward(self, input):
         for module in self:
             input = module.forward(input)
-            if not isinstance(input, Tensor):
-                return TensorPlaceholder()  # We can't infer output shape
         return input
 
     def forward_step(self, input, update_state=True):
@@ -72,8 +70,6 @@ class Sequential(FlattenableStateDict, nn.Sequential, Padded, CoModule):
 
     def forward_steps(self, input: Tensor, pad_end=False, update_state=True):
         for module in self:
-            if len(input) == 0:
-                return input
             if isinstance(module, Padded):
                 input = module.forward_steps(
                     input, pad_end=pad_end, update_state=update_state

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -196,25 +196,23 @@ class _ConvCoNd(_ConvNd, Padded, CoModule):
         return x_out, (next_buffer, next_index, next_stride_index)
 
     def forward_step(self, input: Tensor, update_state=True) -> Tensor:
-        output, (
-            new_buffer,
-            new_state_index,
-            new_stride_index,
-        ) = self._forward_step(input, self.get_state())
+        output, (state_buffer, state_index, stride_index) = self._forward_step(
+            input, self.get_state()
+        )
         if update_state:
-            self.state_buffer = new_buffer
-            self.state_index = new_state_index
-            self.stride_index = new_stride_index
+            self.state_buffer = state_buffer
+            self.state_index = state_index
+            self.stride_index = stride_index
         return output
 
-    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
+    def forward_steps(self, input: Tensor, pad_end=False, update_state=True) -> Tensor:
         assert (
             len(input.shape) == self._input_len
         ), f"A tensor of shape {self.input_shape_desciption} should be passed as input."
 
         outs = []
         for t in range(input.shape[2]):
-            o = self.forward_step(input[:, :, t])
+            o = self.forward_step(input[:, :, t], update_state=update_state)
             if isinstance(o, Tensor):
                 outs.append(o)
 

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -207,7 +207,7 @@ class _ConvCoNd(_ConvNd, Padded, CoModule):
             self.stride_index = new_stride_index
         return output
 
-    def forward_steps(self, input: Tensor, pad_end=True):
+    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
         assert (
             len(input.shape) == self._input_len
         ), f"A tensor of shape {self.input_shape_desciption} should be passed as input."
@@ -236,7 +236,7 @@ class _ConvCoNd(_ConvNd, Padded, CoModule):
             outs = torch.tensor([])
         return outs
 
-    def forward(self, input: Tensor):
+    def forward(self, input: Tensor) -> Tensor:
         """Performs a full forward computation exactly as the regular layer would.
         This method is handy for effient training on clip-based data.
 

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -43,7 +43,7 @@ def forward_stepping(module: nn.Module, dim: int = 2):
 
     def unsqueezed(func: Callable[[Tensor], Tensor]):
         @wraps(func)
-        def call(x: Tensor, update_state=True) -> Tensor:
+        def call(x: Tensor) -> Tensor:
             x = x.unsqueeze(dim)
             x = func(x)
             x = x.squeeze(dim)
@@ -64,7 +64,7 @@ def forward_stepping(module: nn.Module, dim: int = 2):
 
     module.forward = module.forward
     module.forward_steps = with_dummy_args(module.forward)
-    module.forward_step = unsqueezed(module.forward)
+    module.forward_step = with_dummy_args(unsqueezed(module.forward))
     module.delay = 0
     module.clean_state = dummy
 

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -133,7 +133,7 @@ def continual(module: nn.Module) -> CoModule:
         return forward_stepping(module)
 
     assert type(module) in MODULE_MAPPING, (
-        f"A registered conversion for {module.__name__} was not found. "
+        f"A registered conversion for {module} was not found. "
         "You can register a custom conversion as follows:"
         """
         import continual as co

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -57,13 +57,16 @@ class Delay(torch.nn.Module, Padded, CoModule):
         else:
             return None
 
-    def forward_step(self, input: Tensor) -> Tensor:
+    def forward_step(self, input: Tensor, update_state=True) -> Tensor:
         if self._delay == 0:
             return input
 
-        output, (self.state_buffer, self.state_index) = self._forward_step(
+        output, (state_buffer, state_index) = self._forward_step(
             input, self.get_state()
         )
+        if update_state:
+            self.state_buffer = state_buffer
+            self.state_index = state_index
         return output
 
     def _forward_step(self, input: Tensor, prev_state: State) -> Tuple[Tensor, State]:
@@ -86,10 +89,10 @@ class Delay(torch.nn.Module, Padded, CoModule):
 
         return output, (buffer, new_index)
 
-    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
+    def forward_steps(self, input: Tensor, pad_end=False, update_state=True) -> Tensor:
         outs = []
         for t in range(input.shape[2]):
-            o = self.forward_step(input[:, :, t])
+            o = self.forward_step(input[:, :, t], update_state=update_state)
             if isinstance(o, Tensor):
                 outs.append(o)
 

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -43,8 +43,8 @@ class Delay(torch.nn.Module, Padded, CoModule):
         return state_buffer, state_index
 
     def clean_state(self):
-        self.state_buffer = None
-        self.state_index = None
+        del self.state_buffer
+        del self.state_index
 
     def get_state(self):
         if (

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -86,7 +86,7 @@ class Delay(torch.nn.Module, Padded, CoModule):
 
         return output, (buffer, new_index)
 
-    def forward_steps(self, input: Tensor, pad_end=True) -> Tensor:
+    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
         outs = []
         for t in range(input.shape[2]):
             o = self.forward_step(input[:, :, t])

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -118,7 +118,6 @@ class Delay(torch.nn.Module, Padded, CoModule):
 
     def forward(self, input: Tensor) -> Tensor:
         # No delay during regular forward
-        # nan = torch.tensor(float('nan')).repeat(3,2)
         return input
 
     @property

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -57,21 +57,6 @@ class CoModule(ABC):
         This function is identical to the non-continual module found `torch.nn`"""
         ...  # pragma: no cover
 
-    # @property
-    # def delay(self) -> int:
-    #     """Temporal delay of the module
-
-    #     Returns:
-    #         int: Temporal delay of the module
-    #     """
-    #     ...  # pragma: no cover
-
-    # def clean_state(self):
-    #     """Clean module state
-    #     This serves as a dummy function for modules which do not require state-cleanup
-    #     """
-    #     ...  # pragma: no cover
-
 
 class TensorPlaceholder:
     shape: Tuple[int]

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -29,17 +29,17 @@ class CoModule(ABC):
         ]:
             assert callable(
                 getattr(cls, fn, None)
-            ), f"{cls.__name__} should implement a `{fn}` function which performs {description} to satisfy the CoModule interface."
+            ), f"{cls} should implement a `{fn}` function which performs {description} to satisfy the CoModule interface."
 
         assert hasattr(cls, "delay") and type(cls.delay) in {
             int,
             property,
-        }, f"{cls.__name__} should implement a `delay` property to satisfy the CoModule interface."
+        }, f"{cls} should implement a `delay` property to satisfy the CoModule interface."
 
     @staticmethod
     def is_valid(module):
         try:
-            CoModule._validate_class(module.__class__)
+            CoModule._validate_class(module)
         except AssertionError:
             return False
         return True
@@ -94,7 +94,7 @@ class PaddingMode(Enum):
 class Padded:
     """Base class for continual modules with temporal padding"""
 
-    def forward_steps(self, input: Tensor, pad_end=True) -> Tensor:
+    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
         """Forward computation for multiple steps with state initialisation
 
         Args:

--- a/continual/interface.py
+++ b/continual/interface.py
@@ -44,11 +44,11 @@ class CoModule(ABC):
             return False
         return True
 
-    def forward_step(self, input: Tensor) -> Tensor:
+    def forward_step(self, input: Tensor, update_state=True) -> Tensor:
         """Forward computation for a single step with state initialisation"""
         ...  # pragma: no cover
 
-    def forward_steps(self, input: Tensor) -> Tensor:
+    def forward_steps(self, input: Tensor, update_state=True) -> Tensor:
         """Forward computation for multiple steps with state initialisation"""
         ...  # pragma: no cover
 
@@ -94,12 +94,13 @@ class PaddingMode(Enum):
 class Padded:
     """Base class for continual modules with temporal padding"""
 
-    def forward_steps(self, input: Tensor, pad_end=False) -> Tensor:
+    def forward_steps(self, input: Tensor, pad_end=False, update_state=True) -> Tensor:
         """Forward computation for multiple steps with state initialisation
 
         Args:
-            input (Tensor): Layer input
-            pad_end (bool): Whether results for temporal padding at sequence end should be included
+            input (Tensor): Layer input.
+            pad_end (bool): Whether results for temporal padding at sequence end should be included.
+            update_state (bool): Whether internal state should be updated during this operation.
 
         Returns:
             Tensor: Layer output

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -218,7 +218,7 @@ class _PoolNd(Padded, CoModule, nn.Module):
         ) = self._forward_step(input, self.get_state())
         return output
 
-    def forward_steps(self, input: Tensor, pad_end=True):
+    def forward_steps(self, input: Tensor, pad_end=False):
         assert (
             len(input.shape) == self.num_input_dims + 2
         ), f"A tensor of size {self.input_shape_desciption} should be passed as input."

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -160,9 +160,9 @@ class _PoolNd(Padded, CoModule, nn.Module):
         return state_buffer, state_index, stride_index
 
     def clean_state(self):
-        self.state_buffer = None
-        self.state_index = None
-        self.stride_index = None
+        del self.state_buffer
+        del self.state_index
+        del self.stride_index
 
     def get_state(self):
         if (

--- a/continual/pooling.py
+++ b/continual/pooling.py
@@ -210,22 +210,24 @@ class _PoolNd(Padded, CoModule, nn.Module):
 
         return output, (next_buffer, next_index, next_stride_index)
 
-    def forward_step(self, input: Tensor) -> Tensor:
-        output, (
-            self.state_buffer,
-            self.state_index,
-            self.stride_index,
-        ) = self._forward_step(input, self.get_state())
+    def forward_step(self, input: Tensor, update_state=True) -> Tensor:
+        output, (state_buffer, state_index, stride_index) = self._forward_step(
+            input, self.get_state()
+        )
+        if update_state:
+            self.state_buffer = state_buffer
+            self.state_index = state_index
+            self.stride_index = stride_index
         return output
 
-    def forward_steps(self, input: Tensor, pad_end=False):
+    def forward_steps(self, input: Tensor, pad_end=False, update_state=True):
         assert (
             len(input.shape) == self.num_input_dims + 2
         ), f"A tensor of size {self.input_shape_desciption} should be passed as input."
 
         outs = []
         for t in range(input.shape[2]):
-            o = self.forward_step(input[:, :, t])
+            o = self.forward_step(input[:, :, t], update_state=update_state)
             if isinstance(o, Tensor):
                 outs.append(o)
 

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -1,5 +1,8 @@
+from collections import OrderedDict
 from contextlib import contextmanager
 from functools import reduce
+
+from torch import Tensor, nn
 
 
 @contextmanager
@@ -46,3 +49,79 @@ Example:
     >>>     sd = module.state_dict()  # All unnamed nested keys are flattened, e.g. "0.weight" -> "weight"
     >>>     module.load_state_dict(sd)  # Automatically unflattened during loading "weight" -> "0.weight"
 """
+
+
+def state_dict(
+    module: nn.Module, destination=None, prefix="", keep_vars=False, flatten=False
+) -> "OrderedDict[str, Tensor]":
+    """Returns a dictionary containing a whole state of the module.
+
+    Both parameters and persistent buffers (e.g. running averages) are
+    included. Keys are corresponding parameter and buffer names.
+
+    Args:
+        destination (OrderedDict, optional): a dict to which the state is saved.
+        prefix (str, optional): A string prefix for state keys.
+        keep_vars (bool, optional): Whether parameters should not be detached.
+        flatten (bool, optional): whether the state dict keys are flattened (no numeric keys).
+
+    Returns:
+        dict:
+            a dictionary containing a whole state of the module
+
+    Example::
+
+        >>> module.state_dict().keys()
+        ['bias', 'weight']
+
+    """
+    d = nn.Module.state_dict(module, destination, prefix, keep_vars)
+
+    if flatten or flat_state_dict.flatten:
+        flat_keys = [
+            ".".join(part for part in name.split(".") if not part.isdigit())
+            for name in list(d.keys())
+        ]
+        if len(set(flat_keys)) == len(d.keys()):
+            d = OrderedDict(list(zip(flat_keys, d.values())))
+
+    return d
+
+
+def load_state_dict(
+    module: nn.Module,
+    state_dict: "OrderedDict[str, Tensor]",
+    strict: bool = True,
+    flatten=False,
+):
+    """Copies parameters and buffers from :attr:`state_dict` into
+    this module and its descendants. If :attr:`strict` is ``True``, then
+    the keys of :attr:`state_dict` must exactly match the keys returned
+    by this module's :meth:`~torch.nn.Module.state_dict` function.
+
+    Args:
+        state_dict (dict): a dict containing parameters and
+            persistent buffers.
+        strict (bool, optional): whether to strictly enforce that the keys
+            in :attr:`state_dict` match the keys returned by this module's
+            :meth:`~torch.nn.Module.state_dict` function. Default: ``True``
+        flatten (bool, optional): whether the loaded state dict is flattened (no numeric keys) during loading.
+
+
+    Returns:
+        ``NamedTuple`` with ``missing_keys`` and ``unexpected_keys`` fields:
+            * **missing_keys** is a list of str containing the missing keys
+            * **unexpected_keys** is a list of str containing the unexpected keys
+    """
+
+    if flatten or flat_state_dict.flatten:
+        long_keys = nn.Module.state_dict(module, keep_vars=True).keys()
+        short2long = {
+            ".".join(part for part in key.split(".") if not part.isdigit()): key
+            for key in list(long_keys)
+        }
+        state_dict = OrderedDict(
+            [(short2long[key], val) for key, val in state_dict.items()]
+        )
+
+    return nn.Module.load_state_dict(module, state_dict, strict)

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.6.1",
+    version="0.6.2",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.6.2",
+    version="0.7.0",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -89,6 +89,7 @@ def test_sequential_with_TensorPlaceholder():
 
     coseq = co.Sequential.build_from(seq)
     assert coseq.stride == 4
+    assert coseq.padding == 1
 
     target = seq.forward(sample)
 
@@ -166,7 +167,7 @@ def test_parallel():
     torch.nn.init.ones_(c5.weight)
     torch.nn.init.ones_(c3.weight)
     torch.nn.init.ones_(c1.weight)
-    par = co.Parallel(c5, c3, c1)
+    par = co.Parallel(OrderedDict([("c5", c5), ("c3", c3), ("c1", c1)]))
 
     # forward
     out_all = par.forward(input)

--- a/tests/continual/test_container.py
+++ b/tests/continual/test_container.py
@@ -93,7 +93,7 @@ def test_sequential_with_TensorPlaceholder():
     target = seq.forward(sample)
 
     # forward_steps with padding
-    output = coseq.forward_steps(sample)
+    output = coseq.forward_steps(sample, pad_end=True)
 
     assert torch.allclose(target, output)
 

--- a/tests/continual/test_conv.py
+++ b/tests/continual/test_conv.py
@@ -69,7 +69,7 @@ def test_Conv1d_stride():
 
     # Whole time-series
     co_conv.clean_state()
-    output = co_conv.forward_steps(sample)
+    output = co_conv.forward_steps(sample, pad_end=True)
     assert torch.allclose(target, output)
 
 
@@ -305,7 +305,7 @@ def test_complex():
     regular_output = regular(example_clip_large).detach()
 
     co3 = co.Conv3d.build_from(regular, temporal_fill="zeros")
-    co3_output = co3.forward_steps(example_clip_large)
+    co3_output = co3.forward_steps(example_clip_large, pad_end=True)
 
     assert torch.allclose(regular_output, co3_output, atol=5e-8)
 
@@ -323,7 +323,7 @@ def test_forward_continuation():
 
     # Run batch inference and fill memory
     target1 = conv(example_clip)
-    output1 = coconv.forward_steps(example_clip)
+    output1 = coconv.forward_steps(example_clip, pad_end=True)
     assert torch.allclose(target1, output1, atol=1e-7)
 
     # Next forward

--- a/tests/continual/test_convert.py
+++ b/tests/continual/test_convert.py
@@ -1,0 +1,27 @@
+import continual as co
+from torch import nn
+import torch
+
+
+def test_forward_stepping():
+    sample = torch.randn((1, 1, 4, 1, 1))
+
+    regular = nn.Conv3d(1, 1, kernel_size=1, bias=True)
+    target = regular.forward(sample)
+
+    co3 = co.forward_stepping(regular)
+
+    # forward
+    output = co3.forward(sample)
+    assert torch.allclose(output, target)
+
+    # forward_steps
+    output = co3.forward_steps(sample)
+    assert torch.allclose(output, target)
+
+    # forward_step
+    output = co3.forward_step(sample[:, :, 0])
+    assert torch.allclose(output, target[:, :, 0])
+
+    # The original function remains unchanged
+    assert torch.allclose(regular.forward(sample), target)

--- a/tests/continual/test_delay.py
+++ b/tests/continual/test_delay.py
@@ -59,7 +59,7 @@ def test_delay_forward():
     delay = Delay(delay=2, temporal_fill="zeros")
 
     assert torch.equal(example_input, delay.forward(example_input))
-    assert torch.equal(example_input, delay.forward_steps(example_input))
+    assert torch.equal(example_input, delay.forward_steps(example_input, pad_end=True))
 
 
 def test_state():

--- a/tests/continual/test_delay.py
+++ b/tests/continual/test_delay.py
@@ -7,80 +7,72 @@ torch.manual_seed(42)
 
 
 def test_delay_3d():
-    example_input = torch.normal(mean=torch.zeros(4 * 3 * 3)).reshape((1, 1, 4, 3, 3))
+    sample = torch.normal(mean=torch.zeros(4 * 3 * 3)).reshape((1, 1, 4, 3, 3))
     delay = Delay(delay=2, temporal_fill="zeros")
 
-    ones = torch.ones_like(example_input[:, :, 0])
+    ones = torch.ones_like(sample[:, :, 0])
 
-    assert isinstance(delay.forward_step(example_input[:, :, 0]), TensorPlaceholder)
-    assert isinstance(delay.forward_step(example_input[:, :, 1]), TensorPlaceholder)
+    assert isinstance(delay.forward_step(sample[:, :, 0]), TensorPlaceholder)
+    assert isinstance(delay.forward_step(sample[:, :, 1]), TensorPlaceholder)
 
-    assert torch.equal(
-        delay.forward_step(example_input[:, :, 2]), example_input[:, :, 0]
-    )
+    assert torch.equal(delay.forward_step(sample[:, :, 2]), sample[:, :, 0])
 
-    assert torch.equal(
-        delay.forward_step(example_input[:, :, 3]), example_input[:, :, 1]
-    )
+    assert torch.equal(delay.forward_step(sample[:, :, 3]), sample[:, :, 1])
 
-    assert torch.equal(delay.forward_step(ones), example_input[:, :, 2])
+    assert torch.equal(delay.forward_step(ones), sample[:, :, 2])
 
-    assert torch.equal(delay.forward_step(ones), example_input[:, :, 3])
+    assert torch.equal(delay.forward_step(ones), sample[:, :, 3])
 
     assert torch.equal(delay.forward_step(ones), ones)
 
 
 def test_delay_2d():
-    example_input = torch.rand((2, 2, 4, 3))
+    sample = torch.rand((2, 2, 4, 3))
     delay = Delay(delay=2, temporal_fill="zeros")
 
-    ones = torch.ones_like(example_input[:, :, 0])
+    ones = torch.ones_like(sample[:, :, 0])
 
-    assert isinstance(delay.forward_step(example_input[:, :, 0]), TensorPlaceholder)
-    assert isinstance(delay.forward_step(example_input[:, :, 1]), TensorPlaceholder)
+    assert isinstance(delay.forward_step(sample[:, :, 0]), TensorPlaceholder)
+    assert isinstance(delay.forward_step(sample[:, :, 1]), TensorPlaceholder)
 
-    assert torch.equal(
-        delay.forward_step(example_input[:, :, 2]), example_input[:, :, 0]
-    )
+    assert torch.equal(delay.forward_step(sample[:, :, 2]), sample[:, :, 0])
 
-    assert torch.equal(
-        delay.forward_step(example_input[:, :, 3]), example_input[:, :, 1]
-    )
+    assert torch.equal(delay.forward_step(sample[:, :, 3]), sample[:, :, 1])
 
-    assert torch.equal(delay.forward_step(ones), example_input[:, :, 2])
+    assert torch.equal(delay.forward_step(ones), sample[:, :, 2])
 
-    assert torch.equal(delay.forward_step(ones), example_input[:, :, 3])
+    assert torch.equal(delay.forward_step(ones), sample[:, :, 3])
 
     assert torch.equal(delay.forward_step(ones), ones)
 
 
 def test_delay_forward():
-    example_input = torch.rand((2, 2, 4, 3))
+    sample = torch.rand((2, 2, 4, 3))
     delay = Delay(delay=2, temporal_fill="zeros")
 
-    assert torch.equal(example_input, delay.forward(example_input))
-    assert torch.equal(example_input, delay.forward_steps(example_input, pad_end=True))
+    assert torch.equal(sample, delay.forward(sample))
+    assert torch.equal(sample, delay.forward_steps(sample, pad_end=True))
 
 
 def test_state():
-    example_input = torch.rand((2, 2, 4, 3))
+    sample = torch.rand((2, 2, 4, 3))
     delay = Delay(delay=2, temporal_fill="zeros")
 
-    zeros = torch.zeros_like(example_input[:, :, 0])
+    zeros = torch.zeros_like(sample[:, :, 0])
 
     # State stays clean
     assert getattr(delay, "state_buffer", None) is None
     assert getattr(delay, "state_index", None) is None
 
-    delay.forward(example_input)
+    delay.forward(sample)
 
     assert getattr(delay, "state_buffer", None) is None
     assert getattr(delay, "state_index", None) is None
 
     # State is populated
-    delay.forward_step(example_input[:, :, 0])
+    delay.forward_step(sample[:, :, 0])
 
-    assert torch.equal(delay.state_buffer[0], example_input[:, :, 0])
+    assert torch.equal(delay.state_buffer[0], sample[:, :, 0])
     assert torch.equal(delay.state_buffer[1], zeros)
     assert delay.state_index == -1  # still initialising
 
@@ -89,7 +81,21 @@ def test_state():
     assert getattr(delay, "state_buffer", None) is None
     assert getattr(delay, "state_index", None) is None
 
-    assert torch.equal(delay.forward_steps(example_input, pad_end=True), example_input)
+    assert torch.equal(delay.forward_steps(sample, pad_end=True), sample)
     # state has not been flushed
-    assert torch.equal(delay.state_buffer[0], example_input[:, :, 2])
-    assert torch.equal(delay.state_buffer[1], example_input[:, :, 3])
+    assert torch.equal(delay.state_buffer[0], sample[:, :, 2])
+    assert torch.equal(delay.state_buffer[1], sample[:, :, 3])
+
+
+def test_zero_delay():
+    sample = torch.rand((2, 2, 4, 3))
+
+    no_delay = Delay(delay=0)
+    assert torch.equal(no_delay.forward(sample), sample)
+    assert torch.equal(no_delay.forward_steps(sample), sample)
+    assert torch.equal(no_delay.forward_step(sample[:, :, -1]), sample[:, :, -1])
+
+
+def test_repr():
+    delay = Delay(delay=2)
+    assert delay.__repr__() == "Delay(2)"

--- a/tests/continual/test_example.py
+++ b/tests/continual/test_example.py
@@ -46,7 +46,7 @@ def test_mb_conv():
     output = mb_conv.forward(example)
     assert output.shape == (1, 32, 7, 5, 5)
 
-    output_steps = mb_conv.forward_steps(example)
+    output_steps = mb_conv.forward_steps(example, pad_end=True)
     assert output_steps.shape == output.shape
 
 
@@ -81,7 +81,7 @@ def test_inception_module():
     output = inception_module.forward(example)
     assert output.shape == (1, 64 + 128 + 32 + 32, 7, 5, 5)
 
-    output_steps = inception_module.forward_steps(example)
+    output_steps = inception_module.forward_steps(example, pad_end=True)
     assert output_steps.shape == output.shape
 
 
@@ -107,5 +107,5 @@ def test_se():
     output = se.forward(example)
     assert output.shape == example.shape
 
-    output_steps = se.forward_steps(example)
+    output_steps = se.forward_steps(example, pad_end=True)
     assert torch.allclose(output_steps, output)

--- a/tests/continual/test_interface.py
+++ b/tests/continual/test_interface.py
@@ -1,0 +1,13 @@
+from continual import TensorPlaceholder
+
+
+def test_TensorPlaceholder():
+    # No shape
+    tp = TensorPlaceholder()
+    assert tp.size() == tuple()
+    assert len(tp) == 0
+
+    # Shape
+    tp = TensorPlaceholder(shape=(1, 2, 3))
+    assert tp.size() == (1, 2, 3)
+    assert len(tp) == 0

--- a/tests/continual/test_pool.py
+++ b/tests/continual/test_pool.py
@@ -44,7 +44,7 @@ def test_AvgPool1d_padded():
     co_pool = AvgPool1d.build_from(pool)
 
     # Step by step
-    output = co_pool.forward_steps(sample)
+    output = co_pool.forward_steps(sample, pad_end=True)
     assert torch.allclose(target, output)
 
     # Exact

--- a/tests/continual/test_utils.py
+++ b/tests/continual/test_utils.py
@@ -1,0 +1,15 @@
+from continual.utils import temporary_parameter
+
+
+def test_temporary_parameter():
+    class MyClass:
+        def __init__(self) -> None:
+            self.x = 0
+
+    c = MyClass()
+    assert c.x == 0
+
+    with temporary_parameter(c, "x", 42):
+        assert c.x == 42
+
+    assert c.x == 0


### PR DESCRIPTION
### Added
- Independent state_dict and load_state_dict functions.
- Added nonempty check for aggregation functions in Parallel.
- `update_state` argument to all `forward_step(s)` methods.

### Changed
- Changed default pad_end value to False.

### Fixed
- Continual interface and conversion to support both class and module.
