### PR TITLE
Fix torch hooks and ptflops compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,18 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 ## [Unreleased]
 
 
+## [0.11.1]
+### Added
+- Add `call_mode`.
+- Add `warm_up`.
+
+### Changed
+- Container implementations to use `__call__` with alternating call_modes. This change was necessary to propperly trigger the torch hooks needed in `ptflops`.
+
+### Fixed
+- `ptflops` compatibility.
+
+
 ## [0.11.0]
 ### Added
 - `co.Linear` module.

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -12,7 +12,7 @@ from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
 from .convert import continual, forward_stepping  # noqa: F401
 from .delay import Delay  # noqa: F401
 from .linear import Linear  # noqa: F401
-from .module import CoModule, PaddingMode, TensorPlaceholder  # noqa: F401
+from .module import CoModule, PaddingMode, TensorPlaceholder, call_mode  # noqa: F401
 from .pooling import (  # noqa: F401
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,

--- a/continual/closure.py
+++ b/continual/closure.py
@@ -8,7 +8,10 @@ from .module import CoModule
 
 
 class Lambda(CoModule, nn.Module):
-    """Module wrapper for stateless functions"""
+    """Module wrapper for stateless functions
+
+    NB: Operations performed in a Lambda are not counted in `ptflops`
+    """
 
     def __init__(self, fn: Callable[[Tensor], Tensor], unsqueeze_step=True):
         nn.Module.__init__(self)

--- a/continual/conv.py
+++ b/continual/conv.py
@@ -29,7 +29,7 @@ __all__ = [
 ]
 
 
-class _ConvCoNd(_ConvNd, CoModule):
+class _ConvCoNd(CoModule, _ConvNd):
     def __init__(
         self,
         ConvClass: torch.nn.Module,

--- a/continual/delay.py
+++ b/continual/delay.py
@@ -11,7 +11,7 @@ State = Tuple[Tensor, int]
 __all__ = ["Delay"]
 
 
-class Delay(torch.nn.Module, CoModule):
+class Delay(CoModule, torch.nn.Module):
     """Continual delay modules
 
     This module only introduces a delay in the continual modes, i.e. on `forward_step` and `forward_steps`.

--- a/continual/ptflops.py
+++ b/continual/ptflops.py
@@ -1,8 +1,19 @@
 """ Register modules with `ptflops` """
 
-from .conv import Conv1d, Conv2d, Conv3d
+from .closure import Add, Multiply  # noqa: F401
+from .container import (  # noqa: F401
+    Broadcast,
+    BroadcastReduce,
+    Conditional,
+    Parallel,
+    Reduce,
+    Residual,
+    Sequential,
+)
+from .conv import Conv1d, Conv2d, Conv3d  # noqa: F401
+from .linear import Linear  # noqa: F401
 from .logging import getLogger
-from .pooling import (
+from .pooling import (  # noqa: F401
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,
     AdaptiveMaxPool2d,
@@ -39,6 +50,9 @@ def _register_ptflops():
         fc.MODULES_MAPPING[MaxPool3d] = fc.pool_flops_counter_hook
         fc.MODULES_MAPPING[AdaptiveAvgPool3d] = fc.pool_flops_counter_hook
         fc.MODULES_MAPPING[AdaptiveMaxPool3d] = fc.pool_flops_counter_hook
+
+        # Linear
+        fc.MODULES_MAPPING[Linear] = fc.linear_flops_counter_hook
 
     except ModuleNotFoundError:  # pragma: no cover
         pass

--- a/continual/utils.py
+++ b/continual/utils.py
@@ -5,6 +5,18 @@ from functools import reduce
 from torch import Tensor, nn
 
 
+def rsetattr(obj, attr, val):
+    pre, _, post = attr.rpartition(".")
+    return setattr(rgetattr(obj, pre) if pre else obj, post, val)
+
+
+def rgetattr(obj, attr, *args):
+    def _getattr(obj, attr):
+        return getattr(obj, attr, *args)
+
+    return reduce(_getattr, [obj] + attr.split("."))
+
+
 @contextmanager
 def temporary_parameter(obj, attr: str, val):
     do_del = False
@@ -24,18 +36,6 @@ def temporary_parameter(obj, attr: str, val):
         delattr(obj, attr)
     else:
         rsetattr(obj, attr, prev_val)
-
-
-def rsetattr(obj, attr, val):
-    pre, _, post = attr.rpartition(".")
-    return setattr(rgetattr(obj, pre) if pre else obj, post, val)
-
-
-def rgetattr(obj, attr, *args):
-    def _getattr(obj, attr):
-        return getattr(obj, attr, *args)
-
-    return reduce(_getattr, [obj] + attr.split("."))
 
 
 class _FlatStateDict(object):

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.11.0",
+    version="0.11.1",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/tests/continual/test_convert.py
+++ b/tests/continual/test_convert.py
@@ -17,8 +17,13 @@ def test_forward_stepping():
     assert torch.allclose(output, target)
 
     # forward_steps
-    output = co3.forward_steps(sample)
+    output = co3.forward_steps(sample, pad_end=True)  # pad_end doesn't do anything
     assert torch.allclose(output, target)
+
+    # Changing call_mode
+    with co.call_mode("forward_steps"):
+        output2 = co3(sample, pad_end=True)
+    assert torch.allclose(output, output2)
 
     # forward_step
     output = co3.forward_step(sample[:, :, 0])

--- a/tests/continual/test_ptflops.py
+++ b/tests/continual/test_ptflops.py
@@ -1,0 +1,101 @@
+import torch
+from ptflops import get_model_complexity_info
+from torch import nn
+
+import continual as co
+
+
+def test_conv():
+    #            C  T  H  W
+    T = 4
+    input_res = (3, T, 3, 3)
+
+    mod = nn.Conv3d(3, 3, 3, padding=(1, 0, 0))
+    macs, params = get_model_complexity_info(mod, input_res, as_strings=False)
+
+    co_mod = co.Conv3d(3, 3, 3, padding=(1, 0, 0))
+    co_macs, co_params = get_model_complexity_info(co_mod, input_res, as_strings=False)
+
+    assert macs == co_macs
+    assert params == co_params
+
+    co_mod = co.Conv3d(3, 3, 3)  # Padding not necessary
+    with co.call_mode("forward_step"):
+        co_step_macs, co_step_params = get_model_complexity_info(
+            co_mod, (3, 3, 3), as_strings=False
+        )
+
+    assert macs / T == co_step_macs
+    assert params == co_step_params
+
+
+def test_sequential():
+    #            C  T  H  W
+    T = 4
+    input_res = (3, T)
+    convs = [co.Conv1d(3, 3, 3, padding=(1,))]  # , co.Conv1d(3, 3, 3, padding=(1,))]
+    mod = nn.Sequential(*convs)
+    macs, params = get_model_complexity_info(mod, input_res, as_strings=False)
+
+    co_mod = co.Sequential(*convs)
+    co_macs, co_params = get_model_complexity_info(co_mod, input_res, as_strings=False)
+
+    assert macs == co_macs
+    assert params == co_params
+
+    co_mod.call_mode = "forward_step"
+    co_mod.warm_up(step_shape=(1, 3))
+    co_step_macs, co_step_params = get_model_complexity_info(
+        co_mod, (3,), as_strings=False
+    )
+
+    assert macs / T == co_step_macs
+    assert params == co_step_params
+
+
+def test_broadcast_reduce():
+    #            C  T  H  W
+    T = 4
+    input_res = (3, T)
+
+    seq = co.Sequential(
+        co.Conv1d(3, 3, 3, padding=(1,)), co.Conv1d(3, 3, 3, padding=(1,))
+    )
+
+    br = co.BroadcastReduce(
+        co.Conv1d(3, 3, 3, padding=(1,)), co.Conv1d(3, 3, 3, padding=(1,))
+    )
+
+    # forward
+    seq_macs, seq_params = get_model_complexity_info(seq, input_res, as_strings=False)
+    br_macs, br_params = get_model_complexity_info(br, input_res, as_strings=False)
+
+    assert seq_macs == br_macs
+    assert seq_params == br_params
+
+    # warm up
+    seq.forward_steps(torch.randn((1, *input_res)))
+
+    # forward_step
+    with co.call_mode("forward_step"):
+        seq_macs_step, _ = get_model_complexity_info(seq, (3,), as_strings=False)
+        br_macs_step, _ = get_model_complexity_info(br, (3,), as_strings=False)
+
+    assert seq_macs_step == br_macs_step
+    assert seq_macs / T == seq_macs_step
+    assert br_macs / T == br_macs_step
+
+
+def test_converted():
+    T = 4
+    input_res = (3, T)
+
+    mod = co.continual(nn.BatchNorm1d(3))
+    seq_macs, params = get_model_complexity_info(mod, input_res, as_strings=False)
+
+    assert params == 6
+
+    with co.call_mode("forward_step"):
+        step_macs, _ = get_model_complexity_info(mod, (3,), as_strings=False)
+
+    assert seq_macs / T == step_macs


### PR DESCRIPTION
### Added
- Add `call_mode`.
- Add `warm_up`.

### Changed
- Container implementations to use `__call__` with alternating call_modes. This change was necessary to propperly trigger the torch hooks needed in `ptflops`.

### Fixed
- `ptflops` compatibility.