### PR TITLE
Add functor support in Lambda

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ## [Unreleased]
 
+
+## [0.15.2]
 ### Added
 - Support for functor in `co.Lambda`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ## [Unreleased]
 
+### Added
+- Support for functor in `co.Lambda`
+
+### Remove
+- `nn.LayerNorm` from automatically convertible modules
+
+
 ## [0.15.1]
 ### Added
 - `nn.LayerNorm` to automatically convertible modules

--- a/continual/closure.py
+++ b/continual/closure.py
@@ -22,6 +22,8 @@ class Lambda(CoModule, nn.Module):
         nn.Module.__init__(self)
         assert callable(fn), "The pased function should be callable."
         self.fn = fn
+        if not hasattr(self.fn, "__name__") and hasattr(self.fn, "__repr__"):
+            self.fn.__name__ = self.fn.__repr__()
         self.takes_time = takes_time
 
     def __repr__(self) -> str:

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -136,7 +136,6 @@ NAIVE_MAPPING = {
     nn.BatchNorm1d,
     nn.BatchNorm2d,
     nn.BatchNorm3d,
-    nn.LayerNorm,
     # >> Dropout modules
     nn.Dropout,
     nn.Dropout2d,

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ def from_file(file_name: str = "requirements.txt", comment_char: str = "#"):
 
 setup(
     name="continual-inference",
-    version="0.15.1",
+    version="0.15.2",
     description="Building blocks for Continual Inference Networks in PyTorch",
     long_description=long_description(),
     long_description_content_type="text/markdown",

--- a/tests/continual/test_closure.py
+++ b/tests/continual/test_closure.py
@@ -65,6 +65,10 @@ def test_lambda():
     mod = Lambda.build_from(lambda x: torch.ones_like(x) * 42)
     assert torch.equal(target, mod(x))
 
+    # Functor
+    functor = torch.nn.Sigmoid()
+    assert torch.equal(functor(x), Lambda(functor)(x))
+
     # takes_time = False
     mod = Lambda.build_from(lambda x: torch.ones_like(x) * 42, takes_time=True)
     assert torch.equal(target, mod(x))


### PR DESCRIPTION
### Added
- Support for functor in `co.Lambda`

### Remove
- `nn.LayerNorm` from automatically convertible modules