### PR TITLE
Add Continual Transformers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 ### Added
 - Citations for Continual Inference lib paper.
 - Docs.
-- `RecyclingPositionalEncoding`.
+- Continual Transformer modules, including:
+    - `RecyclingPositionalEncoding`.
+    - `RetroactiveMultiheadAttention`.
+    - `SingleOutputMultiheadAttention`.
 
 
 ## [0.16.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 ### Added
 - Citations for Continual Inference lib paper.
 - Docs.
+- `RecyclingPositionalEncoding`.
 
 
 ## [0.16.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 ### Added
 - Citations for Continual Inference lib paper.
 - Docs.
+- Automatic conversion for RNN modules.
 - Continual Transformer modules, including:
     - `RecyclingPositionalEncoding`.
     - `RetroactiveMultiheadAttention`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ## [Unreleased]
 
+## [0.17.0]
+
 ### Added
 - Citations for Continual Inference lib paper.
 - Docs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,13 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 - Docs.
 - Automatic conversion for RNN modules.
 - Continual Transformer modules, including:
-    - `RecyclingPositionalEncoding`.
-    - `RetroactiveMultiheadAttention`.
-    - `SingleOutputMultiheadAttention`.
+    - `RecyclingPositionalEncoding`
+    - `RetroactiveMultiheadAttention`
+    - `SingleOutputMultiheadAttention`
+    - `SingleOutputTransformerEncoderLayer`
+    - `RetroactiveTransformerEncoderLayer`
+    - `TransformerEncoderLayerFactory`
+    - `TransformerEncoder`
 
 
 ## [0.16.0]

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ __PyTorch building blocks for Continual Inference Networks__
     <img src="https://readthedocs.org/projects/continual-inference/badge/?version=latest" alt="Documentation Status" height="20"/>
   </a>
   <a href="https://pepy.tech/project/continual-inference">
-    <img src="https://pepy.tech/badge/continual-inference/month" height="20">
+    <img src="https://pepy.tech/badge/continual-inference" height="20">
   </a>
   <a href="https://codecov.io/gh/LukasHedegaard/continual-inference">
     <img src="https://codecov.io/gh/LukasHedegaard/continual-inference/branch/main/graph/badge.svg?token=XW1UQZSEOG" height="20"/>
@@ -33,7 +33,6 @@ __PyTorch building blocks for Continual Inference Networks__
   <sup>*</sup>
 </div>
 
-\*We match PyTorch interfaces exacly. This reduces the codefactor to "A-" due to method arguments named "input".
 
 ## Install 
 ```bash

--- a/README.md
+++ b/README.md
@@ -217,6 +217,15 @@ Below is a list of the modules and utilities included in the library:
     - `co.LSTM`
     - `co.GRU`
 
+- Transformers:
+    - `co.TransformerEncoder`
+    - `co.TransformerEncoderLayerFactory` - Factory function corresponding to `nn.TransformerEncoderLayer`.
+    - `co.SingleOutputTransformerEncoderLayer` - SingleOutputMHA version of `nn.TransformerEncoderLayer`.
+    - `co.RetroactiveTransformerEncoderLayer` - RetroactiveMHA version of `nn.TransformerEncoderLayer`.
+    - `co.RetroactiveMultiheadAttention` - Retroactive version of `nn.MultiheadAttention`.
+    - `co.SingleOutputMultiheadAttention` - Single-output version of `nn.MultiheadAttention`.
+    - `co.RecyclingPositionalEncoding` - Positional Encoding used for Continual Transformers.
+
 - Containers
     - `co.Sequential` - Sequential wrapper for modules. This module automatically performs conversions of torch.nn modules, which are safe during continual inference. These include all batch normalisation and activation function. 
     - `co.Broadcast` - Broadcast one stream to multiple.

--- a/README.md
+++ b/README.md
@@ -228,6 +228,9 @@ Below is a list of the modules and utilities included in the library:
     - `co.BroadcastReduce` - BroadcastReduce wrapper for modules.
     - `co.Conditional` - Conditionally checks whether to invoke a module at runtime.
 
+- Transformer modules
+    - `co.RecyclingPositionalEncoding` - Positional encoding for continual inference.
+
 - Other
     - `co.Delay` - Pure delay module (e.g. needed in residuals).
     - `co.Reshape` - Reshape non-temporal dimensions.

--- a/continual/__about__.py
+++ b/continual/__about__.py
@@ -1,6 +1,6 @@
 import time
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 __author__ = "Lukas Hedegaard"
 __author_email__ = "lukasxhedegaard@gmail.com"
 __license__ = "Apache-2.0"

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -36,4 +36,8 @@ from .positional_encoding import RecyclingPositionalEncoding  # noqa: F401
 from .ptflops import _register_ptflops  # noqa: F401
 from .rnn import GRU, LSTM, RNN  # noqa: F401
 from .shape import Reshape  # noqa: F401
+from .transformer import (  # noqa: F401
+    TransformerEncoder,
+    TransformerEncoderLayerFactory,
+)
 from .utils import flat_state_dict, load_state_dict, state_dict  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -26,6 +26,7 @@ from .pooling import (  # noqa: F401
     MaxPool2d,
     MaxPool3d,
 )
+from .positional_encoding import RecyclingPositionalEncoding  # noqa: F401
 from .ptflops import _register_ptflops  # noqa: F401
 from .rnn import GRU, LSTM, RNN  # noqa: F401
 from .shape import Reshape  # noqa: F401

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -14,10 +14,8 @@ from .convert import continual, forward_stepping  # noqa: F401
 from .delay import Delay  # noqa: F401
 from .linear import Linear  # noqa: F401
 from .module import CoModule, PaddingMode, TensorPlaceholder, call_mode  # noqa: F401
-from .multihead_attention.retroactive_mha import (  # noqa: F401
+from .multihead_attention import (  # noqa: F401
     RetroactiveMultiheadAttention,
-)
-from .multihead_attention.single_output_mha import (  # noqa: F401
     SingleOutputMultiheadAttention,
 )
 from .pooling import (  # noqa: F401
@@ -37,6 +35,8 @@ from .ptflops import _register_ptflops  # noqa: F401
 from .rnn import GRU, LSTM, RNN  # noqa: F401
 from .shape import Reshape  # noqa: F401
 from .transformer import (  # noqa: F401
+    RetroactiveTransformerEncoderLayer,
+    SingleOutputTransformerEncoderLayer,
     TransformerEncoder,
     TransformerEncoderLayerFactory,
 )

--- a/continual/__init__.py
+++ b/continual/__init__.py
@@ -14,6 +14,12 @@ from .convert import continual, forward_stepping  # noqa: F401
 from .delay import Delay  # noqa: F401
 from .linear import Linear  # noqa: F401
 from .module import CoModule, PaddingMode, TensorPlaceholder, call_mode  # noqa: F401
+from .multihead_attention.retroactive_mha import (  # noqa: F401
+    RetroactiveMultiheadAttention,
+)
+from .multihead_attention.single_output_mha import (  # noqa: F401
+    SingleOutputMultiheadAttention,
+)
 from .pooling import (  # noqa: F401
     AdaptiveAvgPool2d,
     AdaptiveAvgPool3d,

--- a/continual/closure.py
+++ b/continual/closure.py
@@ -56,7 +56,7 @@ class Lambda(CoModule, nn.Module):
         )
 
     def __repr__(self) -> str:
-        s = "Lambda("
+        s = self.__class__.__name__ + "("
         if callable(self.fn):
             s += f"{function_repr(self.fn)}"
         if callable(self.forward_only_fn):

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -208,30 +208,3 @@ register(nn.Sequential, Sequential)
 
 # Closure
 register(FunctionType, Lambda)
-
-
-# Register modules in `ptflops`
-try:
-    from ptflops import flops_counter as fc
-
-    # Conv
-    fc.MODULES_MAPPING[Conv1d] = fc.conv_flops_counter_hook
-    fc.MODULES_MAPPING[Conv2d] = fc.conv_flops_counter_hook
-    fc.MODULES_MAPPING[Conv3d] = fc.conv_flops_counter_hook
-
-    # Pooling
-    fc.MODULES_MAPPING[AvgPool1d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[MaxPool1d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AvgPool2d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[MaxPool2d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AdaptiveAvgPool2d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AdaptiveMaxPool2d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AvgPool3d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[MaxPool3d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AdaptiveAvgPool3d] = fc.pool_flops_counter_hook
-    fc.MODULES_MAPPING[AdaptiveMaxPool3d] = fc.pool_flops_counter_hook
-
-except ModuleNotFoundError:  # pragma: no cover
-    pass
-except Exception as e:  # pragma: no cover
-    logger.warning(f"Failed to add flops_counter_hook: {e}")

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -25,6 +25,7 @@ from .pooling import (
     MaxPool3d,
 )
 from .rnn import GRU, LSTM, RNN
+from .transformer import TransformerEncoder
 
 logger = getLogger(__name__)
 
@@ -48,10 +49,7 @@ def forward_stepping(module: nn.Module, dim: int = 2):
     def forward_step(func: Callable[[Tensor], Tensor]):
         @wraps(func)
         def call(x: Tensor, update_state=True) -> Tensor:
-            x = x.unsqueeze(dim)
-            x = func(x)
-            x = x.squeeze(dim)
-            return x
+            return func(x.unsqueeze(dim)).squeeze(dim)
 
         return call
 
@@ -214,3 +212,6 @@ register(FunctionType, Lambda)
 register(nn.RNN, RNN)
 register(nn.LSTM, LSTM)
 register(nn.GRU, GRU)
+
+# Transformer
+register(nn.TransformerEncoder, TransformerEncoder)

--- a/continual/convert.py
+++ b/continual/convert.py
@@ -24,6 +24,7 @@ from .pooling import (
     MaxPool2d,
     MaxPool3d,
 )
+from .rnn import GRU, LSTM, RNN
 
 logger = getLogger(__name__)
 
@@ -208,3 +209,8 @@ register(nn.Sequential, Sequential)
 
 # Closure
 register(FunctionType, Lambda)
+
+# RNN
+register(nn.RNN, RNN)
+register(nn.LSTM, LSTM)
+register(nn.GRU, GRU)

--- a/continual/multihead_attention/__init__.py
+++ b/continual/multihead_attention/__init__.py
@@ -1,0 +1,2 @@
+from .retroactive_mha import RetroactiveMultiheadAttention  # noqa: F401
+from .single_output_mha import SingleOutputMultiheadAttention  # noqa: F401

--- a/continual/multihead_attention/mha_base.py
+++ b/continual/multihead_attention/mha_base.py
@@ -305,7 +305,7 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
         key_padding_mask: Optional[Tensor] = None,
         need_weights: bool = True,
         attn_mask: Optional[Tensor] = None,
-    ) -> Tuple[Tensor, Optional[Tensor]]:
+    ) -> Union[Tensor, Tuple[Tensor, Tensor]]:
         r"""
         Args:
             query, key, value: map a query and a set of key-value pairs to an output.
@@ -584,3 +584,21 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
             if module.bias_v is not None:
                 comodule.bias_v.copy_(module.bias_v)
         return comodule
+
+
+def scaled_dot_prod_attn_flops(
+    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
+):
+    n = sequence_len
+    d = embed_dim
+
+    flops = 0
+
+    if include_muls:
+        flops += 2 * n * n * d + 2 * n * d
+    if include_adds:
+        flops += 2 * n * n - n * d - n
+    if include_exps:
+        flops += n * n
+
+    return flops

--- a/continual/multihead_attention/mha_base.py
+++ b/continual/multihead_attention/mha_base.py
@@ -8,8 +8,6 @@ from torch.nn.modules.activation import MultiheadAttention
 
 from continual.module import CoModule, TensorPlaceholder
 
-MaybeTensor = Union[Tensor, TensorPlaceholder]
-
 State = List[Tensor]
 
 
@@ -379,14 +377,14 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
         prev_state: State = None,
         *args,
         **kwargs,
-    ) -> Tuple[MaybeTensor, State]:
+    ) -> Tuple[Union[Tensor, TensorPlaceholder], State]:
         """Forward computation for a single step with state initialisation
 
         Args:
             query, key, value: step inputs of shape `(B, E)` where B is the batch size and E is the embedding dimension.
 
         Returns:
-            Tuple[MaybeTensor, State]: Step output and new state.
+            Tuple[Union[Tensor, TensorPlaceholder], State]: Step output and new state.
         """
         if prev_state is None:
             prev_state = (
@@ -435,7 +433,7 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """
         Args:
             query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
@@ -483,7 +481,7 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """Forward computation for multiple steps with state initialisation
 
         Args:

--- a/continual/multihead_attention/mha_base.py
+++ b/continual/multihead_attention/mha_base.py
@@ -12,10 +12,11 @@ State = List[Tensor]
 
 
 def _clone_state(state):
-    return [s.clone() for s in state]
+    return [s.clone() if isinstance(s, torch.Tensor) else s for s in state]
 
 
-def multi_head_attention_forward_step(  # noqa: C901 - copy of impl in PyTorch
+# Copy of torch.nn impl
+def multi_head_attention_forward_step(  # noqa: C901
     scaled_dot_product_attention_step: Callable,
     prev_state: Any,
     query: Tensor,
@@ -41,7 +42,7 @@ def multi_head_attention_forward_step(  # noqa: C901 - copy of impl in PyTorch
     v_proj_weight: Optional[Tensor] = None,
     static_k: Optional[Tensor] = None,
     static_v: Optional[Tensor] = None,
-) -> Tuple[Tensor, Any]:
+) -> Tuple[Tensor, Any]:  # pragma: no cover
     """
     Args:
         query, key, value: map a query and a set of key-value pairs to an output.
@@ -287,15 +288,15 @@ class MultiheadAttentionBase(CoModule, MultiheadAttention):
 
     @abstractmethod
     def get_state(self) -> Optional[Any]:
-        ...
+        ...  # pragma: no cover
 
     @abstractmethod
     def set_state(self, state: Any):
-        ...
+        ...  # pragma: no cover
 
     @abstractmethod
     def clean_state(self):
-        ...
+        ...  # pragma: no cover
 
     def forward(
         self,

--- a/continual/multihead_attention/mha_base.py
+++ b/continual/multihead_attention/mha_base.py
@@ -1,0 +1,588 @@
+from abc import abstractmethod
+from typing import Any, Callable, List, Optional, Tuple, Union
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn.modules.activation import MultiheadAttention
+
+from continual.module import CoModule, TensorPlaceholder
+
+MaybeTensor = Union[Tensor, TensorPlaceholder]
+
+State = List[Tensor]
+
+
+def _clone_state(state):
+    return [s.clone() for s in state]
+
+
+def multi_head_attention_forward_step(  # noqa: C901 - copy of impl in PyTorch
+    scaled_dot_product_attention_step: Callable,
+    prev_state: Any,
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    embed_dim_to_check: int,
+    num_heads: int,
+    in_proj_weight: Tensor,
+    in_proj_bias: Optional[Tensor],
+    bias_k: Optional[Tensor],
+    bias_v: Optional[Tensor],
+    add_zero_attn: bool,
+    dropout_p: float,
+    out_proj_weight: Tensor,
+    out_proj_bias: Optional[Tensor],
+    training: bool = True,
+    key_padding_mask: Optional[Tensor] = None,
+    need_weights: bool = True,
+    attn_mask: Optional[Tensor] = None,
+    use_separate_proj_weight: bool = False,
+    q_proj_weight: Optional[Tensor] = None,
+    k_proj_weight: Optional[Tensor] = None,
+    v_proj_weight: Optional[Tensor] = None,
+    static_k: Optional[Tensor] = None,
+    static_v: Optional[Tensor] = None,
+) -> Tuple[Tensor, Any]:
+    """
+    Args:
+        query, key, value: map a query and a set of key-value pairs to an output.
+            See "Attention Is All You Need" for more details.
+        embed_dim_to_check: total dimension of the model.
+        num_heads: parallel attention heads.
+        in_proj_weight, in_proj_bias: input projection weight and bias.
+        bias_k, bias_v: bias of the key and value sequences to be added at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        dropout_p: probability of an element to be zeroed.
+        out_proj_weight, out_proj_bias: the output projection weight and bias.
+        training: apply dropout if is ``True``.
+        key_padding_mask: if provided, specified padding elements in the key will
+            be ignored by the attention. This is an binary mask. When the value is True,
+            the corresponding value on the attention layer will be filled with -inf.
+        need_weights: output attn_output_weights.
+        attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+            the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+        use_separate_proj_weight: the function accept the proj. weights for query, key,
+            and value in different forms. If false, in_proj_weight will be used, which is
+            a combination of q_proj_weight, k_proj_weight, v_proj_weight.
+        q_proj_weight, k_proj_weight, v_proj_weight, in_proj_bias: input projection weight and bias.
+        static_k, static_v: static key and value used for attention operators.
+
+    Shape:
+        Inputs:
+        - query: :math:`(N, E)` where N is the batch size and E is the embedding dimension.
+        - key: :math:`(N, E)`, where N is the batch size and E is the embedding dimension.
+        - value: :math:`(N, E)` where N is the batch size and E is the embedding dimension.
+        - key_padding_mask: :math:`(N)` where N is the batch size.
+          If a ByteTensor is provided, the non-zero positions will be ignored while the zero positions
+          will be unchanged. If a BoolTensor is provided, the positions with the
+          value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+        - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length.
+          3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
+          S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
+          positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+          while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+          are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+          is provided, it will be added to the attention weight.
+        - static_k: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+          N is the batch size and E is the embedding dimension. E/num_heads is the head dimension.
+        - static_v: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+          N is the batch size and E is the embedding dimension. E/num_heads is the head dimension.
+
+        Outputs:
+        - attn_output: :math:`(N, E)` where N is the batch size and E is the embedding dimension.
+        - state: Internal state for continual computataion.
+    """
+    assert add_zero_attn is False, "add_zero_attn is not supported"
+    assert key_padding_mask is None, "key_padding_mask is not supported"
+    assert attn_mask is None, "attn_mask is not supported"
+    assert static_k is None, "static_k is not supported"
+    assert static_v is None, "static_v is not supported"
+
+    # set up shape vars
+    assert len(query.shape) == 2, "query should have shape (N, E)"
+    assert len(key.shape) == 2, "key should have shape (N, E)"
+    assert len(value.shape) == 2, "value should have shape (N, E)"
+    query = query.unsqueeze(0)  # shape = (1, N, E)
+    key = key.unsqueeze(0)  # shape = (1, N, E)
+    value = value.unsqueeze(0)  # shape = (1, N, E)
+
+    tgt_len, bsz, embed_dim = query.shape
+    src_len, _, _ = key.shape
+    assert (
+        embed_dim == embed_dim_to_check
+    ), f"was expecting embedding dimension of {embed_dim_to_check}, but got {embed_dim}"
+    if isinstance(embed_dim, torch.Tensor):
+        # embed_dim can be a tensor when JIT tracing
+        head_dim = embed_dim.div(num_heads, rounding_mode="trunc")
+    else:
+        head_dim = embed_dim // num_heads
+    assert (
+        head_dim * num_heads == embed_dim
+    ), f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+    if use_separate_proj_weight:
+        # allow MHA to have different embedding dimensions when separate projection weights are used
+        assert (
+            key.shape[:2] == value.shape[:2]
+        ), f"key's sequence and batch dims {key.shape[:2]} do not match value's {value.shape[:2]}"
+    else:
+        assert (
+            key.shape == value.shape
+        ), f"key shape {key.shape} does not match value shape {value.shape}"
+
+    # compute in-projection
+    if not use_separate_proj_weight:
+        # Note: Also works for single step (unqueeze dim 0)
+        q, k, v = F._in_projection_packed(
+            query, key, value, in_proj_weight, in_proj_bias
+        )
+    else:
+        assert (
+            q_proj_weight is not None
+        ), "use_separate_proj_weight is True but q_proj_weight is None"
+        assert (
+            k_proj_weight is not None
+        ), "use_separate_proj_weight is True but k_proj_weight is None"
+        assert (
+            v_proj_weight is not None
+        ), "use_separate_proj_weight is True but v_proj_weight is None"
+        if in_proj_bias is None:
+            b_q = b_k = b_v = None
+        else:
+            b_q, b_k, b_v = in_proj_bias.chunk(3)
+        q, k, v = F._in_projection(
+            query,
+            key,
+            value,
+            q_proj_weight,
+            k_proj_weight,
+            v_proj_weight,
+            b_q,
+            b_k,
+            b_v,
+        )
+
+    # add bias along batch dimension (currently second)
+    if bias_k is not None and bias_v is not None:
+        assert static_k is None, "bias cannot be added to static key."
+        assert static_v is None, "bias cannot be added to static value."
+        k = torch.cat([k, bias_k.repeat(1, bsz, 1)])
+        v = torch.cat([v, bias_v.repeat(1, bsz, 1)])
+        # if attn_mask is not None: TODO: Handle these branches
+        #     attn_mask = F.pad(attn_mask, (0, 1))
+        # if key_padding_mask is not None:
+        #     key_padding_mask = F.pad(key_padding_mask, (0, 1))
+
+    # reshape q, k, v for multihead attention and make em batch first
+    q = q.contiguous().view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
+
+    k = k.contiguous().view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+
+    v = v.contiguous().view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+
+    # update source sequence length after adjustments
+    # src_len = k.size(1)
+
+    # merge key padding and attention masks
+    # if key_padding_mask is not None:  # TODO: Handle this branch
+    #     assert key_padding_mask.shape == (
+    #         bsz,
+    #         src_len,
+    #     ), f"expecting key_padding_mask shape of {(bsz, src_len)}, but got {key_padding_mask.shape}"
+    #     key_padding_mask = (
+    #         key_padding_mask.view(bsz, 1, 1, src_len)
+    #         .expand(-1, num_heads, -1, -1)
+    #         .reshape(bsz * num_heads, 1, src_len)
+    #     )
+    #     if attn_mask is None:
+    #         attn_mask = key_padding_mask
+    #     elif attn_mask.dtype == torch.bool:
+    #         attn_mask = attn_mask.logical_or(key_padding_mask)
+    #     else:
+    #         attn_mask = attn_mask.masked_fill(key_padding_mask, float("-inf"))
+
+    # convert mask to float  # TODO: Handle this branch
+    # if attn_mask is not None and attn_mask.dtype == torch.bool:
+    #     new_attn_mask = torch.zeros_like(attn_mask, dtype=torch.float)
+    #     new_attn_mask.masked_fill_(attn_mask, float("-inf"))
+    #     attn_mask = new_attn_mask
+
+    # adjust dropout probability
+    if not training:
+        dropout_p = 0.0
+
+    # (deep breath) calculate attention and out projection
+    q, k, v = q.squeeze(1), k.squeeze(1), v.squeeze(1)
+    attn_output, new_state = scaled_dot_product_attention_step(
+        prev_state, q, k, v, attn_mask, dropout_p
+    )
+    attn_output = attn_output.transpose(0, 1).contiguous().view(-1, bsz, embed_dim)
+    attn_output = F.linear(attn_output, out_proj_weight, out_proj_bias)
+
+    return attn_output, new_state
+
+
+# Corresponds to MultiheadAttention in Pytorch v1.9
+class MultiheadAttentionBase(CoModule, MultiheadAttention):
+    """
+    Continual MultiHeadAttention Base.
+
+
+    Args:
+        embed_dim: total dimension of the model.
+        num_heads: parallel attention heads.
+        dropout: a Dropout layer on attn_output_weights. Default: 0.0.
+        bias: add bias as module parameter. Default: True.
+        add_bias_kv: add bias to the key and value sequences at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        kdim: total number of features in key. Default: None.
+        vdim: total number of features in value. Default: None.
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False`` (seq, batch, feature).
+        sequence_len: Length of token sequence
+
+    Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+    to :attr:`embed_dim` such that query, key, and value have the same
+    number of features.
+    """
+
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+        sequence_len=None,
+        scaled_dot_product_attention_default_state_fn: Callable = None,
+        scaled_dot_product_attention_step_fn: Callable = None,
+        forward_returns_attn_mask=True,
+        embed_dim_second=False,
+    ) -> None:
+        MultiheadAttention.__init__(
+            self,
+            embed_dim,
+            num_heads,
+            dropout,
+            bias,
+            add_bias_kv,
+            add_zero_attn,
+            kdim,
+            vdim,
+            batch_first,
+            device,
+            dtype,
+        )
+        self.sequence_len = sequence_len
+        self._sdpa_default_state = scaled_dot_product_attention_default_state_fn
+        self._sdpa_step = scaled_dot_product_attention_step_fn
+        self.forward_returns_attn_mask = forward_returns_attn_mask
+        self.embed_dim_second = embed_dim_second
+
+    @abstractmethod
+    def get_state(self) -> Optional[Any]:
+        ...
+
+    @abstractmethod
+    def set_state(self, state: Any):
+        ...
+
+    @abstractmethod
+    def clean_state(self):
+        ...
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        key_padding_mask: Optional[Tensor] = None,
+        need_weights: bool = True,
+        attn_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""
+        Args:
+            query, key, value: map a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+            key_padding_mask: if provided, specified padding elements in the key will
+                be ignored by the attention. When given a binary mask and a value is True,
+                the corresponding value on the attention layer will be ignored. When given
+                a byte mask and a value is non-zero, the corresponding value on the attention
+                layer will be ignored
+            need_weights: output attn_output_weights.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+
+        Shapes for inputs:
+            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
+            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
+              If a ByteTensor is provided, the non-zero positions will be ignored while the position
+              with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
+              value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+            - attn_mask: if a 2D mask: :math:`(L, S)` where L is the target sequence length, S is the
+              source sequence length.
+
+              If a 3D mask: :math:`(N\cdot\text{num\_heads}, L, S)` where N is the batch size, L is the target sequence
+              length, S is the source sequence length. ``attn_mask`` ensure that position i is allowed to attend
+              the unmasked positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+              while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+              is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+              is provided, it will be added to the attention weight.
+
+        Shapes for outputs:
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+              E is the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+            - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
+              L is the target sequence length, S is the source sequence length.
+        """
+        if key is None:
+            key = query
+        if value is None:
+            value = query
+
+        if self.embed_dim_second:
+            # N E T -> N T E
+            query = query.permute(0, 2, 1)
+            key = key.permute(0, 2, 1)
+            value = value.permute(0, 2, 1)
+
+        o, attn_output_weights = MultiheadAttention.forward(
+            self, query, key, value, key_padding_mask, need_weights, attn_mask
+        )
+
+        if self.embed_dim_second:
+            o = o.permute(0, 2, 1)  # N T E -> N E T
+
+        if self.forward_returns_attn_mask:
+            return o, attn_output_weights
+        else:
+            return o
+
+    def _forward_step(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        prev_state: State = None,
+        *args,
+        **kwargs,
+    ) -> Tuple[MaybeTensor, State]:
+        """Forward computation for a single step with state initialisation
+
+        Args:
+            query, key, value: step inputs of shape `(B, E)` where B is the batch size and E is the embedding dimension.
+
+        Returns:
+            Tuple[MaybeTensor, State]: Step output and new state.
+        """
+        if prev_state is None:
+            prev_state = (
+                *self._sdpa_default_state(
+                    batch_size=query.shape[0],
+                    dtype=query.dtype,
+                    device=query.device,
+                ),
+                -self.sequence_len,
+            )
+
+        o, new_state = multi_head_attention_forward_step(
+            self._sdpa_step,
+            prev_state[:-1],
+            query,
+            key,
+            value,
+            self.embed_dim,
+            self.num_heads,
+            self.in_proj_weight,
+            self.in_proj_bias,
+            self.bias_k,
+            self.bias_v,
+            self.add_zero_attn,
+            self.dropout,
+            self.out_proj.weight,
+            self.out_proj.bias,
+            training=self.training,
+        )
+        stride_index = prev_state[-1]
+        if stride_index < 0:
+            stride_index += 1
+
+        new_state = (*new_state, stride_index)
+
+        return (
+            TensorPlaceholder(o.shape) if stride_index < 0 else o,
+            new_state,
+        )
+
+    def forward_step(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """
+        Args:
+            query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+
+        Shapes for inputs:
+            - query: :math:`(N, E)` where L is the target sequence length, N is the batch size, E is
+              the embedding dimension.
+            - key: :math:`(N, E)`, where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+            - value: :math:`(N, E)` where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+
+        Shapes for outputs:
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+              E is the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+        """
+        if key is None:
+            key = query
+        if value is None:
+            value = query
+
+        tmp_state = self.get_state()
+
+        if not update_state and tmp_state:
+            backup_state = _clone_state(tmp_state)
+
+        o, tmp_state = self._forward_step(query, key, value, tmp_state)
+
+        if self.batch_first and not isinstance(o, TensorPlaceholder):
+            o = o.transpose(1, 0)
+
+        if update_state:
+            self.set_state(tmp_state)
+        elif tmp_state is not None:
+            self.set_state(backup_state)
+
+        return o
+
+    def forward_steps(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """Forward computation for multiple steps with state initialisation
+
+        Args:
+            query (Tensor): query.
+            key (Tensor): key.
+            value (Tensor): value.
+            update_state (bool): Whether internal state should be updated during this operation.
+
+        Returns:
+            Tensor: Stepwise layer outputs
+        """
+        if key is None:
+            key = query
+        if value is None:
+            value = query
+
+        if self.embed_dim_second:
+            # N E T -> N T E
+            query = query.permute(0, 2, 1)
+            key = key.permute(0, 2, 1)
+            value = value.permute(0, 2, 1)
+
+        if self.batch_first:
+            # N T E -> T N E
+            query, key, value = [x.transpose(1, 0) for x in (query, key, value)]
+
+        tmp_state = self.get_state()
+
+        if not update_state and tmp_state:
+            backup_state = _clone_state(tmp_state)
+
+        T = query.shape[0]
+        assert T == key.shape[0]
+        assert T == value.shape[0]
+        outs = []
+        for t in range(T):
+            o, tmp_state = self._forward_step(query[t], key[t], value[t], tmp_state)
+
+            if isinstance(o, Tensor):
+                if self.batch_first:
+                    o = o.transpose(0, 1)
+                outs.append(o)
+
+        if update_state:
+            self.set_state(tmp_state)
+        elif backup_state is not None:
+            self.set_state(backup_state)
+
+        if len(outs) == 0:
+            return o
+
+        o = torch.stack(outs, dim=int(self.batch_first))
+
+        return o
+
+    @property
+    def receptive_field(self) -> int:
+        return self.sequence_len
+
+    @classmethod
+    def build_from(cls, module: MultiheadAttention, sequence_len: int, **kwargs):
+        comodule = cls(
+            **{
+                **dict(
+                    embed_dim=module.embed_dim,
+                    num_heads=module.num_heads,
+                    dropout=module.dropout,
+                    bias=module.in_proj_bias is not None,
+                    add_bias_kv=module.bias_k is not None,
+                    add_zero_attn=module.add_zero_attn,
+                    kdim=module.kdim,
+                    vdim=module.vdim,
+                    batch_first=module.batch_first,
+                    device=module.out_proj.weight.device,
+                    dtype=module.out_proj.weight.dtype,
+                    sequence_len=sequence_len,
+                ),
+                **kwargs,
+            }
+        )
+        with torch.no_grad():
+            if module.in_proj_weight is not None:
+                comodule.in_proj_weight.copy_(module.in_proj_weight)
+
+            if module.q_proj_weight is not None:
+                comodule.q_proj_weight.copy_(module.q_proj_weight)
+            if module.k_proj_weight is not None:
+                comodule.k_proj_weight.copy_(module.k_proj_weight)
+            if module.v_proj_weight is not None:
+                comodule.v_proj_weight.copy_(module.v_proj_weight)
+
+            if module.in_proj_bias is not None:
+                comodule.in_proj_bias.copy_(module.in_proj_bias)
+            if module.out_proj is not None:
+                comodule.out_proj.weight.copy_(module.out_proj.weight)
+                if module.out_proj.bias is not None:
+                    comodule.out_proj.bias.copy_(module.out_proj.bias)
+            if module.bias_k is not None:
+                comodule.bias_k.copy_(module.bias_k)
+            if module.bias_v is not None:
+                comodule.bias_v.copy_(module.bias_v)
+        return comodule

--- a/continual/multihead_attention/retroactive_mha.py
+++ b/continual/multihead_attention/retroactive_mha.py
@@ -67,9 +67,9 @@ def _scaled_dot_product_attention_step(
 
         - Output: attention values have shape :math:`(B, Nt, E)`; new state
     """
-    if attn_mask is not None:
+    if attn_mask is not None:  # pragma: no cover
         logger.warning("attn_mask is not supported yet and will be skipped")
-    if dropout_p != 0.0:
+    if dropout_p != 0.0:  # pragma: no cover
         logger.warning("dropout_p is not supported yet and will be skipped")
 
     (

--- a/continual/multihead_attention/retroactive_mha.py
+++ b/continual/multihead_attention/retroactive_mha.py
@@ -8,7 +8,7 @@ from torch import Tensor
 
 from continual.module import CallMode, TensorPlaceholder
 
-from .mha_base import MultiheadAttentionBase
+from .mha_base import MultiheadAttentionBase, scaled_dot_prod_attn_flops
 
 logger = getLogger(__name__)
 
@@ -360,7 +360,7 @@ class RetroactiveMultiheadAttention(MultiheadAttentionBase):
         # Multi-head Scaled Dot-Product Attention
         f += self.num_heads * {
             CallMode.FORWARD: scaled_dot_prod_attn_flops,
-            CallMode.FORWARD_STEP: scaled_dot_prod_attn_step_flops,
+            CallMode.FORWARD_STEP: retractive_scaled_dot_prod_attn_step_flops,
         }[self.call_mode](
             self.sequence_len,
             self.embed_dim // self.num_heads,
@@ -375,25 +375,7 @@ class RetroactiveMultiheadAttention(MultiheadAttentionBase):
         return f
 
 
-def scaled_dot_prod_attn_flops(
-    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
-):
-    n = sequence_len
-    d = embed_dim
-
-    flops = 0
-
-    if include_muls:
-        flops += 2 * n * n * d + 2 * n * d
-    if include_adds:
-        flops += 2 * n * n - n * d - n
-    if include_exps:
-        flops += n * n
-
-    return flops
-
-
-def scaled_dot_prod_attn_step_flops(
+def retractive_scaled_dot_prod_attn_step_flops(
     sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
 ):
     n = sequence_len

--- a/continual/multihead_attention/retroactive_mha.py
+++ b/continual/multihead_attention/retroactive_mha.py
@@ -1,0 +1,410 @@
+import math
+from functools import partial
+from logging import getLogger
+from typing import Optional, Tuple
+
+import torch
+from torch import Tensor
+
+from continual.module import CallMode
+
+from .mha_base import MaybeTensor, MultiheadAttentionBase
+
+logger = getLogger(__name__)
+
+State = Tuple[
+    Tensor,  # d_mem, (B, Nt-1)
+    Tensor,  # AV_mem, (B, Ns-1, E)
+    Tensor,  # Q_mem, (B, Nt-1, E)
+    Tensor,  # K_T_mem, (B, E, Ns)
+    Tensor,  # V_mem, (B, Ns, E)
+]
+
+
+def _scaled_dot_product_attention_default_state(
+    batch_size: int,
+    sequence_len: int,
+    embed_dim: int,
+    num_heads: int,
+    init_fn=torch.zeros,
+    dtype=None,
+    device=None,
+):
+    init_fn = partial(init_fn, dtype=dtype, device=device)
+    E = embed_dim // num_heads
+    B = batch_size * num_heads
+    N = sequence_len
+    d_mem = init_fn((B, N - 1, 1))
+    AV_mem = init_fn((B, N - 1, E))
+    Q_mem = init_fn((B, N - 1, E))
+    K_T_mem = init_fn((B, E, N))
+    V_mem = init_fn((B, N, E))
+    return (d_mem, AV_mem, Q_mem, K_T_mem, V_mem)
+
+
+def _scaled_dot_product_attention_step(
+    prev_state: State,
+    q_step: Tensor,  # step input (B, E)
+    k_step: Tensor,  # step input (B, E)
+    v_step: Tensor,  # step input (B, E)
+    attn_mask: Optional[Tensor] = None,
+    dropout_p: float = 0.0,
+) -> Tuple[Tensor, State]:
+    """
+    Computes the Continual Retroactive Scaled Dot-Product Attention on query, key and value tensors.
+    Returns attended values and updated states.
+
+    Args:
+        q_step, k_step, v_step: query, key and value tensors for a step. See Shape section for shape details.
+        attn_mask: optional tensor containing mask values to be added to calculated
+            attention. May be 2D or 3D; see Shape section for details.
+        dropout_p: dropout probability. If greater than 0.0, dropout is applied.
+
+    Shape:
+        - q_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+        - k_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+        - v_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+
+        - Output: attention values have shape :math:`(B, Nt, E)`; new state
+    """
+    if attn_mask is not None:
+        logger.warning("attn_mask is not supported yet and will be skipped")
+    if dropout_p != 0.0:
+        logger.warning("dropout_p is not supported yet and will be skipped")
+
+    (
+        d_mem,  # (B, Nt-1)
+        AV_mem,  # (B, Ns-1, E)
+        Q_mem,  # (B, Nt-1, E)
+        K_T_mem,  # (B, E, Ns)
+        V_mem,  # (B, Ns, E)
+    ) = prev_state
+
+    B, E = q_step.shape
+    q_step = q_step / math.sqrt(E)
+
+    # Compute oldest and newest entries in attention matrix A:
+    # L . . . R
+    # L . . . R
+    # L . . . R
+    #   B B B B
+
+    # Left column attention values
+    A_left = torch.exp(torch.bmm(Q_mem, K_T_mem[:, :, 0].unsqueeze(-1)))
+
+    # Right column attention values
+    A_right = torch.exp(torch.bmm(Q_mem, k_step.unsqueeze(-1)))
+
+    # Update Q_mem and K_mem
+    Q_mem_new = torch.roll(Q_mem, shifts=-1, dims=(1,))
+    Q_mem_new[:, -1] = q_step
+
+    K_T_mem_new = torch.roll(K_T_mem, shifts=-1, dims=(2,))
+    K_T_mem_new[:, :, -1] = k_step
+
+    # Bottom row attention values
+    A_bottom = torch.exp(torch.bmm(q_step.unsqueeze(1), K_T_mem_new))
+
+    # Compute normalisation
+    d = torch.cat(
+        (
+            d_mem - A_left + A_right,
+            (A_bottom.sum(-1)).unsqueeze(-1),
+        ),
+        dim=1,
+    )
+
+    # Compute AV matrix top
+    AV_sub = torch.bmm(A_left, V_mem[:, 0].unsqueeze(1))
+    AV_add = torch.bmm(A_right, v_step.unsqueeze(1))
+    AV_top = AV_mem - AV_sub + AV_add
+
+    # Update V_mem
+    V_mem_new = torch.roll(V_mem, shifts=-1, dims=(1,))
+    V_mem_new[:, -1] = v_step
+
+    # Compute AV_bottom
+    AV_bottom = torch.bmm(A_bottom, V_mem_new)
+
+    AV_new = torch.cat((AV_top, AV_bottom), dim=1)
+
+    # Compute final output
+    output = AV_new / d
+
+    new_states = (
+        d[:, 1:],  # (B, Nt-1)
+        AV_new[:, 1:],  # (B, Ns-1, E)
+        Q_mem_new,
+        K_T_mem_new,
+        V_mem_new,
+    )
+
+    return output, new_states
+
+
+class RetroactiveMultiheadAttention(MultiheadAttentionBase):
+    """
+    Continual Retroactive MultiHeadAttention.
+    https://arxiv.org/abs/2201.06268
+
+    It augments the MultiHeadAttention in PyTorch with
+    `forward_step` / `forward_steps` functions, in which one / more
+    query, key, and value tokens are passed to yield the multihead attention
+    corresponding to the last (self.sequence_len) tokens.
+
+    Args:
+        embed_dim: total dimension of the model.
+        num_heads: parallel attention heads.
+        dropout: a Dropout layer on attn_output_weights. Default: 0.0.
+        bias: add bias as module parameter. Default: True.
+        add_bias_kv: add bias to the key and value sequences at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        kdim: total number of features in key. Default: None.
+        vdim: total number of features in value. Default: None.
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False`` (seq, batch, feature).
+        sequence_len: Length of token sequence
+
+    Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+    to :attr:`embed_dim` such that query, key, and value have the same
+    number of features.
+    """
+
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+        sequence_len=None,
+        forward_returns_attn_mask=True,
+        embed_dim_second=False,
+    ) -> None:
+        MultiheadAttentionBase.__init__(
+            self,
+            embed_dim,
+            num_heads,
+            dropout,
+            bias,
+            add_bias_kv,
+            add_zero_attn,
+            kdim,
+            vdim,
+            batch_first,
+            device,
+            dtype,
+            sequence_len,
+            partial(
+                _scaled_dot_product_attention_default_state,
+                sequence_len=sequence_len,
+                embed_dim=embed_dim,
+                num_heads=num_heads,
+            ),
+            _scaled_dot_product_attention_step,
+            forward_returns_attn_mask,
+            embed_dim_second,
+        )
+
+    def get_state(self) -> Optional[State]:
+        """Get model state
+
+        Returns:
+            Optional[State]: A State tuple if the model has been initialised and otherwise None.
+        """
+        if (
+            getattr(self, "d_mem", None) is not None
+            and getattr(self, "AV_mem", None) is not None
+            and getattr(self, "Q_mem", None) is not None
+            and getattr(self, "K_T_mem", None) is not None
+            and getattr(self, "V_mem", None) is not None
+            and getattr(self, "stride_index", None) is not None
+        ):
+            return (
+                self.d_mem,
+                self.AV_mem,
+                self.Q_mem,
+                self.K_T_mem,
+                self.V_mem,
+                self.stride_index,
+            )
+
+    def set_state(self, state: State):
+        """Set model state
+
+        Args:
+            state (State): State tuple to set as new internal internal state
+        """
+        (
+            self.d_mem,
+            self.AV_mem,
+            self.Q_mem,
+            self.K_T_mem,
+            self.V_mem,
+            self.stride_index,
+        ) = state
+
+    def clean_state(self):
+        """Clean model state"""
+        if hasattr(self, "d_mem"):
+            del self.d_mem
+        if hasattr(self, "AV_mem"):
+            del self.AV_mem
+        if hasattr(self, "Q_mem"):
+            del self.Q_mem
+        if hasattr(self, "K_T_mem"):
+            del self.K_T_mem
+        if hasattr(self, "V_mem"):
+            del self.V_mem
+        if hasattr(self, "stride_index"):
+            del self.stride_index
+
+    def forward_step(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """
+        Args:
+            query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+
+        Shapes for inputs:
+            - query: :math:`(N, E)` where L is the target sequence length, N is the batch size, E is
+              the embedding dimension.
+            - key: :math:`(N, E)`, where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+            - value: :math:`(N, E)` where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+
+        Shapes for outputs:
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+              E is the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+              :math:`(N, E, L)` if ``batch_first`` and ``embed_dim_second ``True``.
+        """
+        o = MultiheadAttentionBase.forward_step(
+            self, query, key, value, update_state, *args, **kwargs
+        )
+
+        if isinstance(o, Tensor) and self.embed_dim_second:
+            o = o.transpose(1, 2)
+
+        return o
+
+    def forward_steps(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """Forward computation for multiple steps with state initialisation
+
+        Args:
+            query (Tensor): query.
+            key (Tensor): key.
+            value (Tensor): value.
+            update_state (bool): Whether internal state should be updated during this operation.
+
+        Returns:
+            Tensor: Stepwise layer outputs
+        """
+        o = MultiheadAttentionBase.forward_steps(
+            self, query, key, value, update_state, *args, **kwargs
+        )
+
+        if isinstance(o, Tensor) and self.embed_dim_second:
+            o = o.permute(0, 3, 1, 2)  # N T T' E -> N E T T'
+
+        return o
+
+    def flops(self, include_muls=True, include_adds=False, include_exps=False):
+        f = 0
+
+        # Linear projection
+        steps_taken = {
+            CallMode.FORWARD: self.sequence_len,
+            CallMode.FORWARD_STEP: 1,
+        }[self.call_mode]
+
+        f += (
+            steps_taken
+            * self.embed_dim
+            * self.embed_dim
+            * 3  # Assuming equal len for Q, K, and V
+        )
+
+        if include_adds:
+            f += 3 * steps_taken * self.embed_dim * (self.embed_dim - 1)
+
+        if self.in_proj_bias is not None:
+            f += 3 * steps_taken * self.embed_dim
+
+            if include_adds:
+                f += 3 * steps_taken * self.embed_dim
+
+        # Multi-head Scaled Dot-Product Attention
+        f += self.num_heads * {
+            CallMode.FORWARD: scaled_dot_prod_attn_flops,
+            CallMode.FORWARD_STEP: scaled_dot_prod_attn_step_flops,
+        }[self.call_mode](
+            self.sequence_len,
+            self.embed_dim // self.num_heads,
+            include_muls,
+            include_adds,
+            include_exps,
+        )
+
+        # Linear projection
+        f += self.sequence_len * self.embed_dim * (self.embed_dim + 1)
+
+        return f
+
+
+def scaled_dot_prod_attn_flops(
+    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
+):
+    n = sequence_len
+    d = embed_dim
+
+    flops = 0
+
+    if include_muls:
+        flops += 2 * n * n * d + 2 * n * d
+    if include_adds:
+        flops += 2 * n * n - n * d - n
+    if include_exps:
+        flops += n * n
+
+    return flops
+
+
+def scaled_dot_prod_attn_step_flops(
+    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
+):
+    n = sequence_len
+    d = embed_dim
+
+    flops = 0
+
+    if include_muls:
+        flops += 7 * n * d + 2 * n - 3 * d
+    if include_adds:
+        flops += 6 * n * d + 3 * n - 6 * d - 3
+    if include_exps:
+        flops += 3 * n - 2
+
+    return flops

--- a/continual/multihead_attention/retroactive_mha.py
+++ b/continual/multihead_attention/retroactive_mha.py
@@ -1,14 +1,14 @@
 import math
 from functools import partial
 from logging import getLogger
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 from torch import Tensor
 
-from continual.module import CallMode
+from continual.module import CallMode, TensorPlaceholder
 
-from .mha_base import MaybeTensor, MultiheadAttentionBase
+from .mha_base import MultiheadAttentionBase
 
 logger = getLogger(__name__)
 
@@ -144,7 +144,8 @@ def _scaled_dot_product_attention_step(
 
 class RetroactiveMultiheadAttention(MultiheadAttentionBase):
     """
-    Continual Retroactive MultiHeadAttention.
+    Continual Retroactive MultiHeadAttention as proposed by Hedegaard et al. in
+    "Continual Transformers: Redundancy-Free Attention for Online Inference"
     https://arxiv.org/abs/2201.06268
 
     It augments the MultiHeadAttention in PyTorch with
@@ -274,7 +275,7 @@ class RetroactiveMultiheadAttention(MultiheadAttentionBase):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """
         Args:
             query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
@@ -310,7 +311,7 @@ class RetroactiveMultiheadAttention(MultiheadAttentionBase):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """Forward computation for multiple steps with state initialisation
 
         Args:

--- a/continual/multihead_attention/single_output_mha.py
+++ b/continual/multihead_attention/single_output_mha.py
@@ -1,15 +1,15 @@
 import math
 from functools import partial
 from logging import getLogger
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Union
 
 import torch
 import torch.nn.functional as F
 from torch import Tensor
 
-from continual.module import CallMode
+from continual.module import CallMode, TensorPlaceholder
 
-from .mha_base import MaybeTensor, MultiheadAttentionBase
+from .mha_base import MultiheadAttentionBase
 
 logger = getLogger(__name__)
 
@@ -113,7 +113,8 @@ def _scaled_dot_product_attention_step(
 
 class SingleOutputMultiheadAttention(MultiheadAttentionBase):
     """
-    Continual Single-output MultiHeadAttention.
+    Continual Single-output MultiHeadAttention as proposed by Hedegaard et al. in
+    "Continual Transformers: Redundancy-Free Attention for Online Inference"
     https://arxiv.org/abs/2201.06268
 
     Args:
@@ -145,7 +146,7 @@ class SingleOutputMultiheadAttention(MultiheadAttentionBase):
         add_zero_attn=False,
         kdim=None,
         vdim=None,
-        batch_first=False,
+        batch_first=True,
         device=None,
         dtype=None,
         sequence_len=None,
@@ -269,7 +270,7 @@ class SingleOutputMultiheadAttention(MultiheadAttentionBase):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """
         Args:
             query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
@@ -299,7 +300,7 @@ class SingleOutputMultiheadAttention(MultiheadAttentionBase):
         update_state=True,
         *args,
         **kwargs,
-    ) -> MaybeTensor:
+    ) -> Union[Tensor, TensorPlaceholder]:
         """Forward computation for multiple steps with state initialisation
 
         Args:

--- a/continual/multihead_attention/single_output_mha.py
+++ b/continual/multihead_attention/single_output_mha.py
@@ -1,0 +1,390 @@
+import math
+from functools import partial
+from logging import getLogger
+from typing import Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+
+from continual.module import CallMode
+
+from .mha_base import MaybeTensor, MultiheadAttentionBase
+
+logger = getLogger(__name__)
+
+State = Tuple[
+    Tensor,  # Q_mem, (B, Nt-1, E)
+    Tensor,  # K_T_mem, (B, E, Ns)
+    Tensor,  # V_mem, (B, Ns, E)
+]
+
+
+def _scaled_dot_product_attention_default_state(
+    batch_size: int,
+    sequence_len: int,
+    embed_dim: int,
+    num_heads: int,
+    query_index=-1,
+    init_fn=torch.zeros,
+    dtype=None,
+    device=None,
+):
+    init_fn = partial(init_fn, dtype=dtype, device=device)
+    E = embed_dim // num_heads
+    B = batch_size * num_heads
+    N = sequence_len
+    Nq = sequence_len - query_index - 1 if query_index >= 0 else -query_index - 1
+    Q_mem = init_fn((B, Nq, E))
+    K_T_mem = init_fn((B, E, N))
+    V_mem = init_fn((B, N, E))
+    return (Q_mem, K_T_mem, V_mem)
+
+
+def _scaled_dot_product_attention_step(
+    prev_state: State,
+    q_step: Tensor,  # step input (B, E)
+    k_step: Tensor,  # step input (B, E)
+    v_step: Tensor,  # step input (B, E)
+    attn_mask: Optional[Tensor] = None,
+    dropout_p: float = 0.0,
+) -> Tuple[Tensor, State]:
+    """
+    Computes the Continual Singe-output Scaled Dot-Product Attention on query, key and value tensors.
+    Returns attended values and updated states.
+
+    Args:
+        q_step, k_step, v_step: query, key and value tensors for a step. See Shape section for shape details.
+        attn_mask: optional tensor containing mask values to be added to calculated
+            attention. May be 2D or 3D; see Shape section for details.
+        dropout_p: dropout probability. If greater than 0.0, dropout is applied.
+
+    Shape:
+        - q_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+        - k_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+        - v_step: :math:`(B, E)` where B is batch size and E is embedding dimension.
+
+        - Output: attention values have shape :math:`(B, Nt, E)`; new state
+    """
+    if attn_mask is not None:
+        logger.warning("attn_mask is not supported yet and will be skipped")
+    if dropout_p != 0.0:
+        logger.warning("dropout_p is not supported yet and will be skipped")
+
+    (
+        Q_mem,  # (B, Nq, E)
+        K_T_mem,  # (B, E, Ns)
+        V_mem,  # (B, Ns, E)
+    ) = prev_state
+
+    B, E = q_step.shape
+    q_step = q_step / math.sqrt(E)
+    q_sel = (Q_mem[:, 0] if Q_mem.shape[1] > 0 else q_step).unsqueeze(1)
+
+    # Update states
+    # Note: We're allowing the K and V mem to have one more entry than
+    # strictly necessary to simplify computatations.
+
+    K_T_new = torch.roll(K_T_mem, shifts=-1, dims=(2,))
+    K_T_new[:, :, -1] = k_step
+
+    V_new = torch.roll(V_mem, shifts=-1, dims=(1,))
+    V_new[:, -1] = v_step
+
+    attn = torch.bmm(q_sel, K_T_new)
+    attn_sm = F.softmax(attn, dim=-1)
+
+    if dropout_p > 0.0:
+        attn_sm = F.dropout(attn_sm, p=dropout_p)
+
+    # (B, Nt, Ns) x (B, Ns, E) -> (B, Nt, E)
+    output = torch.bmm(attn_sm, V_new)
+
+    if Q_mem.shape[1] > 0:
+        Q_new = torch.roll(Q_mem, shifts=-1, dims=(1,))
+        Q_new[:, -1] = q_step
+    else:
+        Q_new = Q_mem
+
+    new_states = (Q_new, K_T_new, V_new)
+
+    return output, new_states
+
+
+class SingleOutputMultiheadAttention(MultiheadAttentionBase):
+    """
+    Continual Single-output MultiHeadAttention.
+    https://arxiv.org/abs/2201.06268
+
+    Args:
+        embed_dim: total dimension of the model.
+        num_heads: parallel attention heads.
+        dropout: a Dropout layer on attn_output_weights. Default: 0.0.
+        bias: add bias as module parameter. Default: True.
+        add_bias_kv: add bias to the key and value sequences at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        kdim: total number of features in key. Default: None.
+        vdim: total number of features in value. Default: None.
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False`` (seq, batch, feature).
+        sequence_len: Length of token sequence
+
+    Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+    to :attr:`embed_dim` such that query, key, and value have the same
+    number of features.
+    """
+
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+        sequence_len=None,
+        query_index=-1,
+        forward_returns_attn_mask=True,
+        embed_dim_second=False,
+    ) -> None:
+        MultiheadAttentionBase.__init__(
+            self,
+            embed_dim,
+            num_heads,
+            dropout,
+            bias,
+            add_bias_kv,
+            add_zero_attn,
+            kdim,
+            vdim,
+            batch_first,
+            device,
+            dtype,
+            sequence_len,
+            partial(
+                _scaled_dot_product_attention_default_state,
+                sequence_len=sequence_len,
+                embed_dim=embed_dim,
+                num_heads=num_heads,
+                query_index=query_index,
+            ),
+            _scaled_dot_product_attention_step,
+            forward_returns_attn_mask,
+            embed_dim_second,
+        )
+        assert query_index < sequence_len
+        self.query_index = query_index
+
+    def get_state(self) -> Optional[State]:
+        """Get model state
+
+        Returns:
+            Optional[State]: A State tuple if the model has been initialised and otherwise None.
+        """
+        if (
+            getattr(self, "Q_mem", None) is not None
+            and getattr(self, "K_T_mem", None) is not None
+            and getattr(self, "V_mem", None) is not None
+            and getattr(self, "stride_index", None) is not None
+        ):
+            return (
+                self.Q_mem,
+                self.K_T_mem,
+                self.V_mem,
+                self.stride_index,
+            )
+
+    def set_state(self, state: State):
+        """Set model state
+
+        Args:
+            state (State): State tuple to set as new internal internal state
+        """
+        (
+            self.Q_mem,
+            self.K_T_mem,
+            self.V_mem,
+            self.stride_index,
+        ) = state
+
+    def clean_state(self):
+        """Clean model state"""
+        if hasattr(self, "Q_mem"):
+            del self.Q_mem
+        if hasattr(self, "K_T_mem"):
+            del self.K_T_mem
+        if hasattr(self, "V_mem"):
+            del self.V_mem
+        if hasattr(self, "stride_index"):
+            del self.stride_index
+
+    @property
+    def delay(self) -> int:
+        return (
+            self.sequence_len - self.query_index - 1
+            if self.query_index >= 0
+            else -self.query_index - 1
+        )
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        key_padding_mask: Optional[Tensor] = None,
+        need_weights: bool = True,
+        attn_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        if key is None:
+            key = query
+        if value is None:
+            value = query
+
+        # Select a single query entry
+        if self.batch_first:
+            if self.embed_dim_second:
+                query = query[:, :, self.query_index].unsqueeze(2)
+            else:
+                query = query[:, self.query_index].unsqueeze(1)
+        else:
+            query = query[self.query_index].unsqueeze(0)
+
+        o = MultiheadAttentionBase.forward(
+            self, query, key, value, key_padding_mask, need_weights, attn_mask
+        )
+
+        return o
+
+    def forward_step(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """
+        Args:
+            query, key, value: step_inputs for mapping a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+
+        Shapes for inputs:
+            - query: :math:`(N, E)` where L is the target sequence length, N is the batch size, E is
+              the embedding dimension.
+            - key: :math:`(N, E)`, where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+            - value: :math:`(N, E)` where S is the source sequence length, N is the batch size, E is
+              the embedding dimension.
+
+        Shapes for outputs:
+            - attn_output: :math:`(N, E)` where N is the batch size and E is the embedding dimension.
+        """
+        o = MultiheadAttentionBase.forward_step(
+            self, query, key, value, update_state, *args, **kwargs
+        )
+        return o.squeeze(1 if self.batch_first else 0) if isinstance(o, Tensor) else o
+
+    def forward_steps(
+        self,
+        query: Tensor,
+        key: Tensor = None,
+        value: Tensor = None,
+        update_state=True,
+        *args,
+        **kwargs,
+    ) -> MaybeTensor:
+        """Forward computation for multiple steps with state initialisation
+
+        Args:
+            query (Tensor): query.
+            key (Tensor): key.
+            value (Tensor): value.
+            update_state (bool): Whether internal state should be updated during this operation.
+
+        Returns:
+            Tensor: Stepwise layer outputs
+        """
+        o = MultiheadAttentionBase.forward_steps(
+            self, query, key, value, update_state, *args, **kwargs
+        )
+
+        if isinstance(o, Tensor):
+            o = o.squeeze(2)
+            if self.embed_dim_second:
+                o = o.transpose(1, 2)  # N T E -> N E T
+
+        return o
+
+    def flops(self, include_muls=True, include_adds=False, include_exps=False):
+        f = 0
+
+        # Linear projection
+        steps_taken = {
+            CallMode.FORWARD: self.sequence_len,
+            CallMode.FORWARD_STEP: 1,
+        }[self.call_mode]
+
+        f += (
+            steps_taken
+            * self.embed_dim
+            * self.embed_dim
+            * 3  # Assuming equal len for Q, K, and V
+        )
+        if include_adds:
+            f += 3 * steps_taken * self.embed_dim * (self.embed_dim - 1)
+
+        if self.in_proj_bias is not None:
+            f += 3 * steps_taken * self.embed_dim
+
+            if include_adds:
+                f += 3 * steps_taken * self.embed_dim
+
+        # Multi-head Scaled Dot-Product Attention
+        f += self.num_heads * {
+            CallMode.FORWARD: scaled_dot_prod_attn_flops,
+            CallMode.FORWARD_STEP: scaled_dot_prod_attn_step_flops,
+        }[self.call_mode](
+            self.sequence_len,
+            self.embed_dim // self.num_heads,
+            include_muls,
+            include_adds,
+            include_exps,
+        )
+
+        # Linear projection
+        f += 1 * self.embed_dim * (self.embed_dim + 1)
+
+        return f
+
+
+def scaled_dot_prod_attn_flops(
+    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
+):
+    n = sequence_len
+    d = embed_dim
+
+    flops = 0
+
+    if include_muls:
+        flops += 2 * n * d + 2 * d
+    if include_adds:
+        flops += 2 * n * d - d - 1
+    if include_exps:
+        flops += n
+
+    return flops
+
+
+def scaled_dot_prod_attn_step_flops(
+    sequence_len, embed_dim, include_muls=True, include_adds=False, include_exps=False
+):
+    return scaled_dot_prod_attn_flops(
+        sequence_len, embed_dim, include_muls, include_adds, include_exps
+    )

--- a/continual/multihead_attention/single_output_mha.py
+++ b/continual/multihead_attention/single_output_mha.py
@@ -66,9 +66,9 @@ def _scaled_dot_product_attention_step(
 
         - Output: attention values have shape :math:`(B, Nt, E)`; new state
     """
-    if attn_mask is not None:
+    if attn_mask is not None:  # pragma: no cover
         logger.warning("attn_mask is not supported yet and will be skipped")
-    if dropout_p != 0.0:
+    if dropout_p != 0.0:  # pragma: no cover
         logger.warning("dropout_p is not supported yet and will be skipped")
 
     (
@@ -94,7 +94,7 @@ def _scaled_dot_product_attention_step(
     attn = torch.bmm(q_sel, K_T_new)
     attn_sm = F.softmax(attn, dim=-1)
 
-    if dropout_p > 0.0:
+    if dropout_p > 0.0:  # pragma: no cover
         attn_sm = F.dropout(attn_sm, p=dropout_p)
 
     # (B, Nt, Ns) x (B, Ns, E) -> (B, Nt, E)
@@ -335,7 +335,7 @@ class SingleOutputMultiheadAttention(MultiheadAttentionBase):
 
         # Linear projection
         steps_taken = {
-            CallMode.FORWARD: self.sequence_len,
+            CallMode.FORWARD: 1 if self.single_output_forward else self.sequence_len,
             CallMode.FORWARD_STEP: 1,
         }[self.call_mode]
 

--- a/continual/positional_encoding.py
+++ b/continual/positional_encoding.py
@@ -1,0 +1,134 @@
+import numpy as np
+import torch
+from torch import Tensor, nn
+
+import continual as co
+
+
+class CyclicPositionalEncoding(nn.Module):
+    """Cyclic PositionalE ncoding as proposed by Ma et al. in
+    "Learning to Iteratively Solve Routing Problems with Dual-Aspect Collaborative Transformer"
+    https://arxiv.org/abs/2110.02544
+    """
+
+    def __init__(self, num_embeddings: int, embedding_dim: int, mean_pooling=True):
+        super(CyclicPositionalEncoding, self).__init__()
+
+        self.num_embeddings = num_embeddings
+        self.embedding_dim = embedding_dim
+        skip_base = np.power(num_embeddings, 1 / (embedding_dim // 2))
+        skip_set = np.linspace(
+            skip_base, num_embeddings, embedding_dim // 2, dtype="int"
+        )
+        x = np.zeros((num_embeddings, embedding_dim))
+
+        def basesin(x, omiga, fai=0):
+            T = 2 * np.pi / omiga
+            return np.sin(omiga * np.abs(np.mod(x, 2 * T) - T) + fai)
+
+        def basecos(x, omiga, fai=0):
+            T = 2 * np.pi / omiga
+            return np.cos(omiga * np.abs(np.mod(x, 2 * T) - T) + fai)
+
+        for i in range(embedding_dim):
+            # see Appendix B
+            skip = (
+                skip_set[i // 3 * 3 + 1]
+                if (i // 3 * 3 + 1) < (embedding_dim // 2)
+                else skip_set[-1]
+            )
+
+            # get z(i) in the paper (via longer_pattern)
+            if num_embeddings > skip:
+                longer_pattern = np.arange(
+                    0, np.ceil((num_embeddings) / skip) * skip + 0.01, 0.01
+                )
+            else:
+                longer_pattern = np.arange(0, num_embeddings + 0.01, 0.01)
+                skip = num_embeddings
+
+            num = len(longer_pattern) - 1
+            omiga = 2 * np.pi / skip
+
+            # see Appendix B
+            fai = (
+                0
+                if i <= (embedding_dim // 2)
+                else 2 * np.pi * ((-i + (embedding_dim // 2)) / (embedding_dim // 2))
+            )
+
+            # Eq. (4) in the paper
+            if i % 2 == 1:
+                x[:, i] = basecos(longer_pattern, omiga, fai)[
+                    np.linspace(0, num, num_embeddings + 1, dtype="int")
+                ][:num_embeddings]
+            else:
+                x[:, i] = basesin(longer_pattern, omiga, fai)[
+                    np.linspace(0, num, num_embeddings + 1, dtype="int")
+                ][:num_embeddings]
+
+        pattern = torch.from_numpy(x).type(torch.FloatTensor)
+        pattern_sum = torch.zeros_like(pattern)
+
+        # Averaging the adjacient embeddings if needed (optional, almost the same performance)
+        arange = torch.arange(num_embeddings)
+        pooling = [0] if not mean_pooling else [-2, -1, 0, 1, 2]
+        time = 0
+        for i in pooling:
+            time += 1
+            index = (arange + i + num_embeddings) % num_embeddings
+            pattern_sum += pattern.gather(0, index.view(-1, 1).expand_as(pattern))
+        pattern = 1.0 / time * pattern_sum - pattern.mean(0)
+        self.register_buffer("pattern", pattern)
+
+    def forward(self, input: Tensor) -> Tensor:
+        return self.pattern[input]
+
+
+class RecyclingPositionalEncoding(co.CoModule, nn.Module):
+    def __init__(
+        self,
+        embed_dim: int,
+        num_embeds: int,
+        learned=True,
+        forward_update_index_steps=1,
+    ):
+        nn.Module.__init__(self)
+        self.pe = {True: nn.Embedding, False: CyclicPositionalEncoding}[learned](
+            num_embeds, embed_dim
+        )
+        self.index = 0
+        self.forward_update_index_steps = forward_update_index_steps
+
+    def forward(self, input: Tensor, update_index_steps: int = None) -> Tensor:
+        T = input.shape[2]
+        assert T <= self.pe.num_embeddings
+        position_ids = (
+            torch.arange(T, device=input.device).unsqueeze(0) + self.index
+        ) % self.pe.num_embeddings
+
+        index_update = (
+            self.forward_update_index_steps
+            if update_index_steps is None
+            else update_index_steps
+        )
+        self.index = (self.index + index_update) % self.pe.num_embeddings
+
+        position_embeddings = self.pe(position_ids).transpose(1, 2)
+        return input + position_embeddings
+
+    def forward_steps(self, input: Tensor, pad_end=False, update_state=True) -> Tensor:
+        return self.forward(
+            input, update_index_steps=input.shape[2] if update_state else 0
+        )
+
+    def forward_step(self, input: Tensor, update_state=True) -> Tensor:
+        output = input + self.pe(torch.tensor([self.index]))
+
+        if update_state:
+            self.index = (self.index + 1) % self.pe.num_embeddings
+        return output
+
+    def clean_state(self):
+        """Clean model state"""
+        self.index = 0

--- a/continual/ptflops.py
+++ b/continual/ptflops.py
@@ -40,7 +40,7 @@ def _register_ptflops():
 
         if hasattr(ptflops, "pytorch_ops"):  # >= v0.6.8
             fc = ptflops.pytorch_ops
-        else:  # < v0.6.7
+        else:  # < v0.6.7 # pragma: no cover
             fc = ptflops.flops_counter
 
         def get_hook(Module):

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -1,0 +1,376 @@
+from collections import OrderedDict
+from enum import Enum
+from functools import reduce
+from typing import Callable, Sequence, Tuple, Union
+
+import torch
+from torch import Tensor, nn
+
+from continual.delay import State as DelayState
+from continual.module import TensorPlaceholder
+
+from .closure import Lambda
+from .container import BroadcastReduce, Residual, Sequential
+from .delay import Delay, PaddingMode
+from .linear import Linear
+from .multihead_attention import (
+    RetroactiveMultiheadAttention,
+    SingleOutputMultiheadAttention,
+)
+
+__all__ = ["TransformerEncoder", "TransformerEncoderLayerFactory", "MhaType"]
+
+
+class MhaType(Enum):
+    """Type of Multi-head Attention
+    Supported tupes are:
+    - RETROACTIVE:      RetroactiveMultiheadAttention
+    - SINGLE_OUTPUT:    SingleOutputMultiheadAttention
+    - REGULAR:          nn.MultiheadAttention
+    """
+
+    RETROACTIVE = "retroactive"
+    SINGLE_OUTPUT = "single_output"
+    REGULAR = "regular"
+
+
+class SelectOrDelay(Delay):
+    """Select a temporal index during forward, or delay correspondingly during forward_step(s)"""
+
+    def forward(self, x: Tensor) -> Union[Tensor, TensorPlaceholder]:
+        assert len(x.shape) >= 3  # N, C, T
+        return x[:, :, -1 - self._delay].unsqueeze(2)
+
+
+class RetroactiveUnity(Delay):
+    """Unity mapping during forward. During forward_step(s), a single-to-many mapping is assumed,
+    and all cached values are output."""
+
+    def __init__(
+        self,
+        delay: int,
+        temporal_fill: PaddingMode = "zeros",
+        auto_shrink: bool = False,
+        time_dim=-1,
+    ):
+        """Initialise Delay block
+
+        Args:
+            delay (int): the number of steps to delay an output.
+            temporal_fill (PaddingMode, optional): Temporal state initialisation mode ("zeros" or "replicate"). Defaults to "zeros".
+            auto_shrink (int, optional): Whether to shrink the temporal dimension of the feature map during forward.
+                This is handy for residuals that are parallel to modules which reduce the number of temporal steps. Defaults to False.
+            time_dim (int, optional): Which dimension to concatenate step outputs along
+        """
+        self.time_dim = time_dim
+        Delay.__init__(self, delay, temporal_fill, auto_shrink)
+
+    def init_state(
+        self,
+        first_output: Tensor,
+    ) -> DelayState:
+        padding = self.make_padding(first_output)
+        state_buffer = torch.stack([padding for _ in range(self.delay + 1)], dim=0)
+        state_index = -self.delay
+        if not hasattr(self, "state_buffer"):
+            self.register_buffer("state_buffer", state_buffer, persistent=False)
+        return state_buffer, state_index
+
+    def _forward_step(
+        self, input: Tensor, prev_state: DelayState
+    ) -> Tuple[Tensor, DelayState]:
+        if prev_state is None:
+            buffer, index = self.init_state(input)
+        else:
+            buffer, index = prev_state
+
+        # Update state
+        buffer[index % (self.delay + 1)] = input
+        new_index = index + 1
+        if new_index > 0:
+            new_index = new_index % self.delay
+
+        # Get output
+        if index >= 0:
+            output = buffer.clone().roll(shifts=-index - 1, dims=0)
+            idx = (
+                self.time_dim + len(output.shape)
+                if self.time_dim < 0
+                else self.time_dim
+            )
+            output = output.permute(
+                list(range(1, idx + 1)) + [0] + list(range(idx + 1, len(output.shape)))
+            )
+        else:
+            output = TensorPlaceholder(buffer[0].shape)
+
+        return output, (buffer, new_index)
+
+
+class RetroactiveLambda(Lambda):
+    """
+    Lambda wrapper for functions that are applied after retroactive modules.
+    """
+
+    def forward(self, input: Tensor) -> Tensor:
+        return Lambda.forward(self, input)
+
+    def forward_step(self, input: Tensor, *args, **kwargs) -> Tensor:
+        return self.forward(input)
+
+    def forward_steps(self, input: Tensor, *args, **kwargs) -> Tensor:
+        return torch.stack(
+            [self.forward(input[:, :, t]) for t in range(input.shape[2])], dim=2
+        )
+
+    @staticmethod
+    def build_from(
+        fn: Callable[[Tensor], Tensor], takes_time=False
+    ) -> "RetroactiveLambda":
+        return RetroactiveLambda(fn, takes_time)
+
+
+class NaiveResidual(nn.Module):
+    def __init__(self, fn):
+        super().__init__()
+        self.fn = fn
+
+    def forward(self, x):
+        return self.fn(x) + x
+
+
+def sum_last_pairs(inputs: Sequence[Tensor]) -> Tensor:
+    if inputs[0].shape != inputs[1].shape:
+        T_min = min(inputs[i].shape[2] for i in range(len(inputs)))
+        inputs = [inp[:, :, -T_min:] for inp in inputs]
+    return reduce(torch.Tensor.add, inputs[1:], inputs[0])
+
+
+def SingleOutputTransformerEncoderLayer(
+    d_model: int,
+    nhead: int,
+    dim_feedforward: int = 2048,
+    dropout: float = 0.1,
+    activation: Union[nn.Module, Callable[[Tensor], Tensor]] = nn.functional.relu,
+    layer_norm_eps: float = 1e-5,
+    # batch_first: bool = True,
+    # norm_first: bool = False,
+    device=None,
+    dtype=None,
+    sequence_len: int = None,
+):
+
+    factory_kwargs = {"device": device, "dtype": dtype}
+    norm1 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+    norm2 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+
+    mha = SingleOutputMultiheadAttention(
+        embed_dim=d_model,
+        num_heads=nhead,
+        dropout=dropout,
+        bias=True,
+        batch_first=True,
+        embed_dim_second=True,
+        query_index=-1,
+        device=device,
+        dtype=dtype,
+        sequence_len=sequence_len,
+        forward_returns_attn_mask=False,
+    )
+
+    ff = Sequential(
+        OrderedDict(
+            [
+                ("linear1", Linear(d_model, dim_feedforward, **factory_kwargs)),
+                ("activation", activation),
+                # Bad name, kept for weight-compat with torch impl:
+                ("dropout", nn.Dropout(dropout)),
+                ("linear2", Linear(dim_feedforward, d_model, **factory_kwargs)),
+                ("dropout2", nn.Dropout(dropout)),
+            ]
+        )
+    )
+
+    return Sequential(
+        BroadcastReduce(
+            OrderedDict(
+                [
+                    ("residual", SelectOrDelay(mha.delay)),
+                    ("self_atn", mha),
+                ]
+            ),
+            reduce=sum_last_pairs,
+            auto_delay=False,
+        ),
+        Sequential(
+            OrderedDict(
+                [
+                    ("norm1", Lambda(norm1, takes_time=False)),
+                    ("_ff_block", Residual(ff)),
+                    ("norm2", Lambda(norm2, takes_time=False)),
+                ]
+            )
+        ),
+    )
+
+
+def RetroactiveTransformerEncoderLayer(
+    d_model: int,
+    nhead: int,
+    dim_feedforward: int = 2048,
+    dropout: float = 0.1,
+    activation: Union[nn.Module, Callable[[Tensor], Tensor]] = nn.functional.relu,
+    layer_norm_eps: float = 1e-5,
+    # batch_first: bool = True,
+    # norm_first: bool = False,
+    device=None,
+    dtype=None,
+    sequence_len: int = None,
+):
+    factory_kwargs = {"device": device, "dtype": dtype}
+    norm1 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+    norm2 = nn.LayerNorm(d_model, eps=layer_norm_eps, **factory_kwargs)
+
+    mha = RetroactiveMultiheadAttention(
+        embed_dim=d_model,
+        num_heads=nhead,
+        dropout=dropout,
+        bias=True,
+        batch_first=True,
+        embed_dim_second=True,
+        device=device,
+        dtype=dtype,
+        sequence_len=sequence_len,
+        forward_returns_attn_mask=False,
+    )
+
+    ff = Sequential(
+        OrderedDict(
+            [
+                ("linear1", Linear(d_model, dim_feedforward, **factory_kwargs)),
+                ("activation", activation),
+                # Bad name, kept for weight-compat with torch impl:
+                ("dropout", nn.Dropout(dropout)),
+                ("linear2", Linear(dim_feedforward, d_model, **factory_kwargs)),
+                ("dropout2", nn.Dropout(dropout)),
+            ]
+        )
+    )
+
+    return Sequential(
+        BroadcastReduce(
+            OrderedDict(
+                [
+                    ("residual", RetroactiveUnity(mha.delay)),
+                    ("self_atn", mha),
+                ]
+            ),
+            reduce="sum",
+            auto_delay=False,
+        ),
+        RetroactiveLambda(
+            nn.Sequential(
+                OrderedDict(
+                    [
+                        ("norm1", norm1),
+                        ("_ff_block", NaiveResidual(ff)),
+                        ("norm2", norm2),
+                    ]
+                )
+            )
+        ),
+    )
+
+
+def StepLocalTransformerEncoderLayer(
+    d_model: int,
+    nhead: int,
+    dim_feedforward: int = 2048,
+    dropout: float = 0.1,
+    activation: Union[nn.Module, Callable[[Tensor], Tensor]] = nn.functional.relu,
+    layer_norm_eps: float = 1e-5,
+    # batch_first: bool = True,
+    # norm_first: bool = False,
+    device=None,
+    dtype=None,
+    sequence_len: int = None,
+):
+    ...
+
+
+def TransformerEncoderLayerFactory(
+    d_model: int,
+    nhead: int,
+    dim_feedforward: int = 2048,
+    dropout: float = 0.1,
+    activation: Union[nn.Module, Callable[[Tensor], Tensor]] = nn.functional.relu,
+    layer_norm_eps: float = 1e-5,
+    # batch_first: bool = True,
+    # norm_first: bool = False,
+    device=None,
+    dtype=None,
+    sequence_len: int = None,
+) -> Callable[[str], Sequential]:
+    def TransformerEncoderLayer(mha_type: MhaType):
+
+        factory_fn = {
+            MhaType.RETROACTIVE: RetroactiveTransformerEncoderLayer,
+            MhaType.SINGLE_OUTPUT: SingleOutputTransformerEncoderLayer,
+            MhaType.REGULAR: StepLocalTransformerEncoderLayer,
+        }[MhaType(mha_type)]
+
+        return factory_fn(
+            d_model,
+            nhead,
+            dim_feedforward,
+            dropout,
+            activation,
+            layer_norm_eps,
+            # batch_first
+            # norm_first
+            device,
+            dtype,
+            sequence_len,
+        )
+
+    return TransformerEncoderLayer
+
+
+def TransformerEncoder(encoder_layer, num_layers, norm: nn.Module = None):
+    """Continual Transformer Encoder as proposed by Hedegaard et al. in
+    "Continual Transformers: Redundancy-Free Attention for Online Inference"
+    https://arxiv.org/abs/2201.06268TransformerEncoder
+
+    This class deviates from the Pytorch implementation in the following ways:
+    - `encoder_layer` parameter takes a factory functor, TransformerEncoderLayerFactory
+    - `mask` and `src_key_padding_mask` are not supported currently.
+
+    Args:
+        num_layers: the number of sub-encoder-layers in the encoder (required).
+        norm: the layer normalization component (optional).
+
+    Examples::
+        >>> transformer_encoder = co.TransformerEncoder(num_layers=2)
+        >>> src = torch.rand(10, 512, 32)
+        >>> out = transformer_encoder(src)
+    """
+
+    layers = []
+    if num_layers == 1:
+        layers.append(("block1", encoder_layer(MhaType.SINGLE_OUTPUT)))
+    else:
+        layers.append(("block1", encoder_layer(MhaType.RETROACTIVE)))
+        for i in range(2, num_layers - 1):
+            layers.append((f"block{i}", encoder_layer(MhaType.REGULAR)))
+        layers.append((f"block{num_layers}", encoder_layer(MhaType.SINGLE_OUTPUT)))
+
+    if norm is not None:
+        layers.append(("norm", norm))
+
+    return Sequential(OrderedDict([layers]))
+
+
+def build_transformer_encoder_from(
+    trans_enc: nn.TransformerEncoder, sequence_len: int
+) -> Sequential:
+    ...

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -146,6 +146,7 @@ def sum_last_pairs(inputs: Sequence[Tensor]) -> Tensor:
     return reduce(torch.Tensor.add, inputs[1:], inputs[0])
 
 
+# TODO: Inherit from Sequential to add attributed and methods such as build_from?
 def SingleOutputTransformerEncoderLayer(
     d_model: int,
     nhead: int,
@@ -213,7 +214,7 @@ def SingleOutputTransformerEncoderLayer(
         ),
     )
 
-
+# TODO: Inherit from Sequential to add attributed and methods such as build_from?
 def RetroactiveTransformerEncoderLayer(
     d_model: int,
     nhead: int,
@@ -281,7 +282,7 @@ def RetroactiveTransformerEncoderLayer(
         ),
     )
 
-
+# TODO: impl
 def StepLocalTransformerEncoderLayer(
     d_model: int,
     nhead: int,
@@ -296,7 +297,6 @@ def StepLocalTransformerEncoderLayer(
     sequence_len: int = None,
 ):
     ...
-
 
 def TransformerEncoderLayerFactory(
     d_model: int,
@@ -336,6 +336,7 @@ def TransformerEncoderLayerFactory(
     return TransformerEncoderLayer
 
 
+# TODO: Inherit from Sequential to add attributed and methods such as build_from?
 def TransformerEncoder(encoder_layer, num_layers, norm: nn.Module = None):
     """Continual Transformer Encoder as proposed by Hedegaard et al. in
     "Continual Transformers: Redundancy-Free Attention for Online Inference"
@@ -370,6 +371,7 @@ def TransformerEncoder(encoder_layer, num_layers, norm: nn.Module = None):
     return Sequential(OrderedDict([layers]))
 
 
+# TODO: impl and merge with TransformerEncoder
 def build_transformer_encoder_from(
     trans_enc: nn.TransformerEncoder, sequence_len: int
 ) -> Sequential:

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -214,6 +214,7 @@ def SingleOutputTransformerEncoderLayer(
         ),
     )
 
+
 # TODO: Inherit from Sequential to add attributed and methods such as build_from?
 def RetroactiveTransformerEncoderLayer(
     d_model: int,
@@ -282,6 +283,7 @@ def RetroactiveTransformerEncoderLayer(
         ),
     )
 
+
 # TODO: impl
 def StepLocalTransformerEncoderLayer(
     d_model: int,
@@ -297,6 +299,7 @@ def StepLocalTransformerEncoderLayer(
     sequence_len: int = None,
 ):
     ...
+
 
 def TransformerEncoderLayerFactory(
     d_model: int,

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -4,6 +4,6 @@ flake8-black
 isort>=5.7
 pytest
 pytest-cov
-ptflops>=0.6
+ptflops>=0.6.8
 numpy
 pytorch_lightning

--- a/tests/continual/multihead_attention/mha.py
+++ b/tests/continual/multihead_attention/mha.py
@@ -1,0 +1,785 @@
+# This file is largely a copy of torch.nn.modules.activation.py
+# and is included as an implementation reference
+
+import math
+import warnings
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+from torch import Tensor
+from torch.nn.init import constant_, xavier_normal_, xavier_uniform_
+from torch.nn.modules.linear import NonDynamicallyQuantizableLinear
+from torch.nn.parameter import Parameter
+from torch.overrides import handle_torch_function, has_torch_function
+
+
+def _in_projection_packed(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    w: Tensor,
+    b: Optional[Tensor] = None,
+) -> List[Tensor]:
+    r"""
+    Performs the in-projection step of the attention operation, using packed weights.
+    Output is a triple containing projection tensors for query, key and value.
+
+    Args:
+        q, k, v: query, key and value tensors to be projected. For self-attention,
+            these are typically the same tensor; for encoder-decoder attention,
+            k and v are typically the same tensor. (We take advantage of these
+            identities for performance if they are present.) Regardless, q, k and v
+            must share a common embedding dimension; otherwise their shapes may vary.
+        w: projection weights for q, k and v, packed into a single tensor. Weights
+            are packed along dimension 0, in q, k, v order.
+        b: optional projection biases for q, k and v, packed into a single tensor
+            in q, k, v order.
+
+    Shape:
+        Inputs:
+        - q: :math:`(..., E)` where E is the embedding dimension
+        - k: :math:`(..., E)` where E is the embedding dimension
+        - v: :math:`(..., E)` where E is the embedding dimension
+        - w: :math:`(E * 3, E)` where E is the embedding dimension
+        - b: :math:`E * 3` where E is the embedding dimension
+
+        Output:
+        - in output list :math:`[q', k', v']`, each output tensor will have the
+            same shape as the corresponding input tensor.
+    """
+    E = q.size(-1)
+    if k is v:
+        if q is k:
+            # self-attention
+            return F.linear(q, w, b).chunk(3, dim=-1)
+        else:
+            # encoder-decoder attention
+            w_q, w_kv = w.split([E, E * 2])
+            if b is None:
+                b_q = b_kv = None
+            else:
+                b_q, b_kv = b.split([E, E * 2])
+            return (F.linear(q, w_q, b_q),) + F.linear(k, w_kv, b_kv).chunk(2, dim=-1)
+    else:
+        w_q, w_k, w_v = w.chunk(3)
+        if b is None:
+            b_q = b_k = b_v = None
+        else:
+            b_q, b_k, b_v = b.chunk(3)
+        return F.linear(q, w_q, b_q), F.linear(k, w_k, b_k), F.linear(v, w_v, b_v)
+
+
+def _in_projection(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    w_q: Tensor,
+    w_k: Tensor,
+    w_v: Tensor,
+    b_q: Optional[Tensor] = None,
+    b_k: Optional[Tensor] = None,
+    b_v: Optional[Tensor] = None,
+) -> Tuple[Tensor, Tensor, Tensor]:
+    r"""
+    Performs the in-projection step of the attention operation. This is simply
+    a triple of linear projections, with shape constraints on the weights which
+    ensure embedding dimension uniformity in the projected outputs.
+    Output is a triple containing projection tensors for query, key and value.
+
+    Args:
+        q, k, v: query, key and value tensors to be projected.
+        w_q, w_k, w_v: weights for q, k and v, respectively.
+        b_q, b_k, b_v: optional biases for q, k and v, respectively.
+
+    Shape:
+        Inputs:
+        - q: :math:`(Qdims..., Eq)` where Eq is the query embedding dimension and Qdims are any
+            number of leading dimensions.
+        - k: :math:`(Kdims..., Ek)` where Ek is the key embedding dimension and Kdims are any
+            number of leading dimensions.
+        - v: :math:`(Vdims..., Ev)` where Ev is the value embedding dimension and Vdims are any
+            number of leading dimensions.
+        - w_q: :math:`(Eq, Eq)`
+        - w_k: :math:`(Eq, Ek)`
+        - w_v: :math:`(Eq, Ev)`
+        - b_q: :math:`(Eq)`
+        - b_k: :math:`(Eq)`
+        - b_v: :math:`(Eq)`
+
+        Output: in output triple :math:`(q', k', v')`,
+         - q': :math:`[Qdims..., Eq]`
+         - k': :math:`[Kdims..., Eq]`
+         - v': :math:`[Vdims..., Eq]`
+
+    """
+    Eq, Ek, Ev = q.size(-1), k.size(-1), v.size(-1)
+    assert w_q.shape == (
+        Eq,
+        Eq,
+    ), f"expecting query weights shape of {(Eq, Eq)}, but got {w_q.shape}"
+    assert w_k.shape == (
+        Eq,
+        Ek,
+    ), f"expecting key weights shape of {(Eq, Ek)}, but got {w_k.shape}"
+    assert w_v.shape == (
+        Eq,
+        Ev,
+    ), f"expecting value weights shape of {(Eq, Ev)}, but got {w_v.shape}"
+    assert b_q is None or b_q.shape == (
+        Eq,
+    ), f"expecting query bias shape of {(Eq,)}, but got {b_q.shape}"
+    assert b_k is None or b_k.shape == (
+        Eq,
+    ), f"expecting key bias shape of {(Eq,)}, but got {b_k.shape}"
+    assert b_v is None or b_v.shape == (
+        Eq,
+    ), f"expecting value bias shape of {(Eq,)}, but got {b_v.shape}"
+    return F.linear(q, w_q, b_q), F.linear(k, w_k, b_k), F.linear(v, w_v, b_v)
+
+
+#
+# multihead attention
+#
+
+
+def _scaled_dot_product_attention(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    attn_mask: Optional[Tensor] = None,
+    dropout_p: float = 0.0,
+) -> Tuple[Tensor, Tensor]:
+    r"""
+    Computes scaled dot product attention on query, key and value tensors, using
+    an optional attention mask if passed, and applying dropout if a probability
+    greater than 0.0 is specified.
+    Returns a tensor pair containing attended values and attention weights.
+
+    Args:
+        q, k, v: query, key and value tensors. See Shape section for shape details.
+        attn_mask: optional tensor containing mask values to be added to calculated
+            attention. May be 2D or 3D; see Shape section for details.
+        dropout_p: dropout probability. If greater than 0.0, dropout is applied.
+
+    Shape:
+        - q: :math:`(B, Nt, E)` where B is batch size, Nt is the target sequence length,
+            and E is embedding dimension.
+        - key: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+            and E is embedding dimension.
+        - value: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+            and E is embedding dimension.
+        - attn_mask: either a 3D tensor of shape :math:`(B, Nt, Ns)` or a 2D tensor of
+            shape :math:`(Nt, Ns)`.
+
+        - Output: attention values have shape :math:`(B, Nt, E)`; attention weights
+            have shape :math:`(B, Nt, Ns)`
+    """
+    B, Nt, E = q.shape
+    q = q / math.sqrt(E)
+    # (B, Nt, E) x (B, E, Ns) -> (B, Nt, Ns)
+    attn = torch.bmm(q, k.transpose(-2, -1))
+    if attn_mask is not None:
+        attn += attn_mask
+    attn_sm = F.softmax(attn, dim=-1)
+    if dropout_p > 0.0:
+        attn_sm = F.dropout(attn_sm, p=dropout_p)
+    # (B, Nt, Ns) x (B, Ns, E) -> (B, Nt, E)
+    output = torch.bmm(attn_sm, v)
+    return output, attn_sm
+
+
+def _scaled_dot_product_attention_mod(
+    q: Tensor,
+    k: Tensor,
+    v: Tensor,
+    attn_mask: Optional[Tensor] = None,
+    dropout_p: float = 0.0,
+) -> Tuple[Tensor, Tensor]:
+    r"""
+    Computes scaled dot product attention on query, key and value tensors, using
+    an optional attention mask if passed, and applying dropout if a probability
+    greater than 0.0 is specified.
+    Returns a tensor pair containing attended values and attention weights.
+    This is a modified version, which computes softmax in an alternative way.
+
+    Args:
+        q, k, v: query, key and value tensors. See Shape section for shape details.
+        attn_mask: optional tensor containing mask values to be added to calculated
+            attention. May be 2D or 3D; see Shape section for details.
+        dropout_p: dropout probability. If greater than 0.0, dropout is applied.
+
+    Shape:
+        - q: :math:`(B, Nt, E)` where B is batch size, Nt is the target sequence length,
+            and E is embedding dimension.
+        - key: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+            and E is embedding dimension.
+        - value: :math:`(B, Ns, E)` where B is batch size, Ns is the source sequence length,
+            and E is embedding dimension.
+        - attn_mask: either a 3D tensor of shape :math:`(B, Nt, Ns)` or a 2D tensor of
+            shape :math:`(Nt, Ns)`.
+
+        - Output: attention values have shape :math:`(B, Nt, E)`; attention weights
+            have shape :math:`(B, Nt, Ns)`
+    """
+    B, Nt, E = q.shape
+    q = q / math.sqrt(E)
+    # (B, Nt, E) x (B, E, Ns) -> (B, Nt, Ns)
+    attn = torch.bmm(q, k.transpose(-2, -1))
+    if attn_mask is not None:
+        attn += attn_mask
+
+    attn_exp = torch.exp(attn)
+    norm = attn_exp.sum(dim=-1)  # over key dim
+    if dropout_p > 0.0:
+        attn_exp = F.dropout(attn_exp, p=dropout_p)
+    # (B, Nt, Ns) x (B, Ns, E) -> (B, Nt, E)
+    av = torch.bmm(attn_exp, v)
+    output = av / norm.unsqueeze(-1)
+
+    return output, attn
+
+
+# Copy of multi_head_attention_forward in PyTorch v1.9
+def multi_head_attention_forward(  # noqa: C901
+    query: Tensor,
+    key: Tensor,
+    value: Tensor,
+    embed_dim_to_check: int,
+    num_heads: int,
+    in_proj_weight: Tensor,
+    in_proj_bias: Optional[Tensor],
+    bias_k: Optional[Tensor],
+    bias_v: Optional[Tensor],
+    add_zero_attn: bool,
+    dropout_p: float,
+    out_proj_weight: Tensor,
+    out_proj_bias: Optional[Tensor],
+    training: bool = True,
+    key_padding_mask: Optional[Tensor] = None,
+    need_weights: bool = True,
+    attn_mask: Optional[Tensor] = None,
+    use_separate_proj_weight: bool = False,
+    q_proj_weight: Optional[Tensor] = None,
+    k_proj_weight: Optional[Tensor] = None,
+    v_proj_weight: Optional[Tensor] = None,
+    static_k: Optional[Tensor] = None,
+    static_v: Optional[Tensor] = None,
+) -> Tuple[Tensor, Optional[Tensor]]:
+    r"""
+    Args:
+        query, key, value: map a query and a set of key-value pairs to an output.
+            See "Attention Is All You Need" for more details.
+        embed_dim_to_check: total dimension of the model.
+        num_heads: parallel attention heads.
+        in_proj_weight, in_proj_bias: input projection weight and bias.
+        bias_k, bias_v: bias of the key and value sequences to be added at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        dropout_p: probability of an element to be zeroed.
+        out_proj_weight, out_proj_bias: the output projection weight and bias.
+        training: apply dropout if is ``True``.
+        key_padding_mask: if provided, specified padding elements in the key will
+            be ignored by the attention. This is an binary mask. When the value is True,
+            the corresponding value on the attention layer will be filled with -inf.
+        need_weights: output attn_output_weights.
+        attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+            the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+        use_separate_proj_weight: the function accept the proj. weights for query, key,
+            and value in different forms. If false, in_proj_weight will be used, which is
+            a combination of q_proj_weight, k_proj_weight, v_proj_weight.
+        q_proj_weight, k_proj_weight, v_proj_weight, in_proj_bias: input projection weight and bias.
+        static_k, static_v: static key and value used for attention operators.
+
+
+    Shape:
+        Inputs:
+        - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+          the embedding dimension.
+        - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+          the embedding dimension.
+        - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+          the embedding dimension.
+        - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
+          If a ByteTensor is provided, the non-zero positions will be ignored while the zero positions
+          will be unchanged. If a BoolTensor is provided, the positions with the
+          value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+        - attn_mask: 2D mask :math:`(L, S)` where L is the target sequence length, S is the source sequence length.
+          3D mask :math:`(N*num_heads, L, S)` where N is the batch size, L is the target sequence length,
+          S is the source sequence length. attn_mask ensures that position i is allowed to attend the unmasked
+          positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+          while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+          are not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+          is provided, it will be added to the attention weight.
+        - static_k: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+          N is the batch size, E is the embedding dimension. E/num_heads is the head dimension.
+        - static_v: :math:`(N*num_heads, S, E/num_heads)`, where S is the source sequence length,
+          N is the batch size, E is the embedding dimension. E/num_heads is the head dimension.
+
+        Outputs:
+        - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+          E is the embedding dimension.
+        - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
+          L is the target sequence length, S is the source sequence length.
+    """
+    tens_ops = (
+        query,
+        key,
+        value,
+        in_proj_weight,
+        in_proj_bias,
+        bias_k,
+        bias_v,
+        out_proj_weight,
+        out_proj_bias,
+    )
+    if has_torch_function(tens_ops):
+        return handle_torch_function(
+            multi_head_attention_forward,
+            tens_ops,
+            query,
+            key,
+            value,
+            embed_dim_to_check,
+            num_heads,
+            in_proj_weight,
+            in_proj_bias,
+            bias_k,
+            bias_v,
+            add_zero_attn,
+            dropout_p,
+            out_proj_weight,
+            out_proj_bias,
+            training=training,
+            key_padding_mask=key_padding_mask,
+            need_weights=need_weights,
+            attn_mask=attn_mask,
+            use_separate_proj_weight=use_separate_proj_weight,
+            q_proj_weight=q_proj_weight,
+            k_proj_weight=k_proj_weight,
+            v_proj_weight=v_proj_weight,
+            static_k=static_k,
+            static_v=static_v,
+        )
+
+    # set up shape vars
+    tgt_len, bsz, embed_dim = query.shape
+    src_len, _, _ = key.shape
+    assert (
+        embed_dim == embed_dim_to_check
+    ), f"was expecting embedding dimension of {embed_dim_to_check}, but got {embed_dim}"
+    if isinstance(embed_dim, torch.Tensor):
+        # embed_dim can be a tensor when JIT tracing
+        head_dim = embed_dim.div(num_heads, rounding_mode="trunc")
+    else:
+        head_dim = embed_dim // num_heads
+    assert (
+        head_dim * num_heads == embed_dim
+    ), f"embed_dim {embed_dim} not divisible by num_heads {num_heads}"
+    if use_separate_proj_weight:
+        # allow MHA to have different embedding dimensions when separate projection weights are used
+        assert (
+            key.shape[:2] == value.shape[:2]
+        ), f"key's sequence and batch dims {key.shape[:2]} do not match value's {value.shape[:2]}"
+    else:
+        assert (
+            key.shape == value.shape
+        ), f"key shape {key.shape} does not match value shape {value.shape}"
+
+    #
+    # compute in-projection
+    #
+    if not use_separate_proj_weight:
+        q, k, v = _in_projection_packed(query, key, value, in_proj_weight, in_proj_bias)
+    else:
+        assert (
+            q_proj_weight is not None
+        ), "use_separate_proj_weight is True but q_proj_weight is None"
+        assert (
+            k_proj_weight is not None
+        ), "use_separate_proj_weight is True but k_proj_weight is None"
+        assert (
+            v_proj_weight is not None
+        ), "use_separate_proj_weight is True but v_proj_weight is None"
+        if in_proj_bias is None:
+            b_q = b_k = b_v = None
+        else:
+            b_q, b_k, b_v = in_proj_bias.chunk(3)
+        q, k, v = _in_projection(
+            query,
+            key,
+            value,
+            q_proj_weight,
+            k_proj_weight,
+            v_proj_weight,
+            b_q,
+            b_k,
+            b_v,
+        )
+
+    # prep attention mask
+    if attn_mask is not None:
+        if attn_mask.dtype == torch.uint8:
+            warnings.warn(
+                "Byte tensor for attn_mask in nn.MultiheadAttention is deprecated. Use bool tensor instead."
+            )
+            attn_mask = attn_mask.to(torch.bool)
+        else:
+            assert (
+                attn_mask.is_floating_point() or attn_mask.dtype == torch.bool
+            ), f"Only float, byte, and bool types are supported for attn_mask, not {attn_mask.dtype}"
+        # ensure attn_mask's dim is 3
+        if attn_mask.dim() == 2:
+            correct_2d_size = (tgt_len, src_len)
+            if attn_mask.shape != correct_2d_size:
+                raise RuntimeError(
+                    f"The shape of the 2D attn_mask is {attn_mask.shape}, but should be {correct_2d_size}."
+                )
+            attn_mask = attn_mask.unsqueeze(0)
+        elif attn_mask.dim() == 3:
+            correct_3d_size = (bsz * num_heads, tgt_len, src_len)
+            if attn_mask.shape != correct_3d_size:
+                raise RuntimeError(
+                    f"The shape of the 3D attn_mask is {attn_mask.shape}, but should be {correct_3d_size}."
+                )
+        else:
+            raise RuntimeError(
+                f"attn_mask's dimension {attn_mask.dim()} is not supported"
+            )
+
+    # prep key padding mask
+    if key_padding_mask is not None and key_padding_mask.dtype == torch.uint8:
+        warnings.warn(
+            "Byte tensor for key_padding_mask in nn.MultiheadAttention is deprecated. Use bool tensor instead."
+        )
+        key_padding_mask = key_padding_mask.to(torch.bool)
+
+    # add bias along batch dimension (currently second)
+    if bias_k is not None and bias_v is not None:
+        assert static_k is None, "bias cannot be added to static key."
+        assert static_v is None, "bias cannot be added to static value."
+        k = torch.cat([k, bias_k.repeat(1, bsz, 1)])
+        v = torch.cat([v, bias_v.repeat(1, bsz, 1)])
+        if attn_mask is not None:
+            attn_mask = F.pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = F.pad(key_padding_mask, (0, 1))
+    else:
+        assert bias_k is None
+        assert bias_v is None
+
+    #
+    # reshape q, k, v for multihead attention and make em batch first
+    #
+    q = q.contiguous().view(tgt_len, bsz * num_heads, head_dim).transpose(0, 1)
+    if static_k is None:
+        k = k.contiguous().view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+    else:
+        # TODO finish disentangling control flow so we don't do in-projections when statics are passed
+        assert (
+            static_k.size(0) == bsz * num_heads
+        ), f"expecting static_k.size(0) of {bsz * num_heads}, but got {static_k.size(0)}"
+        assert (
+            static_k.size(2) == head_dim
+        ), f"expecting static_k.size(2) of {head_dim}, but got {static_k.size(2)}"
+        k = static_k
+    if static_v is None:
+        v = v.contiguous().view(-1, bsz * num_heads, head_dim).transpose(0, 1)
+    else:
+        # TODO finish disentangling control flow so we don't do in-projections when statics are passed
+        assert (
+            static_v.size(0) == bsz * num_heads
+        ), f"expecting static_v.size(0) of {bsz * num_heads}, but got {static_v.size(0)}"
+        assert (
+            static_v.size(2) == head_dim
+        ), f"expecting static_v.size(2) of {head_dim}, but got {static_v.size(2)}"
+        v = static_v
+
+    # add zero attention along batch dimension (now first)
+    if add_zero_attn:
+        zero_attn_shape = (bsz * num_heads, 1, head_dim)
+        k = torch.cat(
+            [k, torch.zeros(zero_attn_shape, dtype=k.dtype, device=k.device)], dim=1
+        )
+        v = torch.cat(
+            [v, torch.zeros(zero_attn_shape, dtype=v.dtype, device=v.device)], dim=1
+        )
+        if attn_mask is not None:
+            attn_mask = F.pad(attn_mask, (0, 1))
+        if key_padding_mask is not None:
+            key_padding_mask = F.pad(key_padding_mask, (0, 1))
+
+    # update source sequence length after adjustments
+    src_len = k.size(1)
+
+    # merge key padding and attention masks
+    if key_padding_mask is not None:
+        assert key_padding_mask.shape == (
+            bsz,
+            src_len,
+        ), f"expecting key_padding_mask shape of {(bsz, src_len)}, but got {key_padding_mask.shape}"
+        key_padding_mask = (
+            key_padding_mask.view(bsz, 1, 1, src_len)
+            .expand(-1, num_heads, -1, -1)
+            .reshape(bsz * num_heads, 1, src_len)
+        )
+        if attn_mask is None:
+            attn_mask = key_padding_mask
+        elif attn_mask.dtype == torch.bool:
+            attn_mask = attn_mask.logical_or(key_padding_mask)
+        else:
+            attn_mask = attn_mask.masked_fill(key_padding_mask, float("-inf"))
+
+    # convert mask to float
+    if attn_mask is not None and attn_mask.dtype == torch.bool:
+        new_attn_mask = torch.zeros_like(attn_mask, dtype=torch.float)
+        new_attn_mask.masked_fill_(attn_mask, float("-inf"))
+        attn_mask = new_attn_mask
+
+    # adjust dropout probability
+    if not training:
+        dropout_p = 0.0
+
+    #
+    # (deep breath) calculate attention and out projection
+    #
+    attn_output, attn_output_weights = _scaled_dot_product_attention(
+        q, k, v, attn_mask, dropout_p
+    )
+    attn_output = attn_output.transpose(0, 1).contiguous().view(tgt_len, bsz, embed_dim)
+    attn_output = F.linear(attn_output, out_proj_weight, out_proj_bias)
+
+    if need_weights:
+        # average attention weights over heads
+        attn_output_weights = attn_output_weights.view(bsz, num_heads, tgt_len, src_len)
+        return attn_output, attn_output_weights.sum(dim=1) / num_heads
+    else:
+        return attn_output, None
+
+
+# Copy of MultiheadAttention in Pytorch v1.9
+class MultiheadAttention(torch.nn.Module):
+    r"""Allows the model to jointly attend to information
+    from different representation subspaces.
+    See `Attention Is All You Need <https://arxiv.org/abs/1706.03762>`_
+
+    .. math::
+        \text{MultiHead}(Q, K, V) = \text{Concat}(head_1,\dots,head_h)W^O
+
+    where :math:`head_i = \text{Attention}(QW_i^Q, KW_i^K, VW_i^V)`.
+
+    Args:
+        embed_dim: total dimension of the model.
+        num_heads: parallel attention heads.
+        dropout: a Dropout layer on attn_output_weights. Default: 0.0.
+        bias: add bias as module parameter. Default: True.
+        add_bias_kv: add bias to the key and value sequences at dim=0.
+        add_zero_attn: add a new batch of zeros to the key and
+                       value sequences at dim=1.
+        kdim: total number of features in key. Default: None.
+        vdim: total number of features in value. Default: None.
+        batch_first: If ``True``, then the input and output tensors are provided
+            as (batch, seq, feature). Default: ``False`` (seq, batch, feature).
+
+    Note that if :attr:`kdim` and :attr:`vdim` are None, they will be set
+    to :attr:`embed_dim` such that query, key, and value have the same
+    number of features.
+
+    Examples::
+
+        >>> multihead_attn = nn.MultiheadAttention(embed_dim, num_heads)
+        >>> attn_output, attn_output_weights = multihead_attn(query, key, value)
+    """
+    __constants__ = ["batch_first"]
+    bias_k: Optional[torch.Tensor]
+    bias_v: Optional[torch.Tensor]
+
+    def __init__(
+        self,
+        embed_dim,
+        num_heads,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+    ) -> None:
+        factory_kwargs = {"device": device, "dtype": dtype}
+        super(MultiheadAttention, self).__init__()
+        self.embed_dim = embed_dim
+        self.kdim = kdim if kdim is not None else embed_dim
+        self.vdim = vdim if vdim is not None else embed_dim
+        self._qkv_same_embed_dim = self.kdim == embed_dim and self.vdim == embed_dim
+
+        self.num_heads = num_heads
+        self.dropout = dropout
+        self.batch_first = batch_first
+        self.head_dim = embed_dim // num_heads
+        assert (
+            self.head_dim * num_heads == self.embed_dim
+        ), "embed_dim must be divisible by num_heads"
+
+        if self._qkv_same_embed_dim is False:
+            self.q_proj_weight = Parameter(
+                torch.empty((embed_dim, embed_dim), **factory_kwargs)
+            )
+            self.k_proj_weight = Parameter(
+                torch.empty((embed_dim, self.kdim), **factory_kwargs)
+            )
+            self.v_proj_weight = Parameter(
+                torch.empty((embed_dim, self.vdim), **factory_kwargs)
+            )
+            self.register_parameter("in_proj_weight", None)
+        else:
+            self.in_proj_weight = Parameter(
+                torch.empty((3 * embed_dim, embed_dim), **factory_kwargs)
+            )
+            self.register_parameter("q_proj_weight", None)
+            self.register_parameter("k_proj_weight", None)
+            self.register_parameter("v_proj_weight", None)
+
+        if bias:
+            self.in_proj_bias = Parameter(torch.empty(3 * embed_dim, **factory_kwargs))
+        else:
+            self.register_parameter("in_proj_bias", None)
+        self.out_proj = NonDynamicallyQuantizableLinear(
+            embed_dim, embed_dim, bias=bias, **factory_kwargs
+        )
+
+        if add_bias_kv:
+            self.bias_k = Parameter(torch.empty((1, 1, embed_dim), **factory_kwargs))
+            self.bias_v = Parameter(torch.empty((1, 1, embed_dim), **factory_kwargs))
+        else:
+            self.bias_k = self.bias_v = None
+
+        self.add_zero_attn = add_zero_attn
+
+        self._reset_parameters()
+
+    def _reset_parameters(self):
+        if self._qkv_same_embed_dim:
+            xavier_uniform_(self.in_proj_weight)
+        else:
+            xavier_uniform_(self.q_proj_weight)
+            xavier_uniform_(self.k_proj_weight)
+            xavier_uniform_(self.v_proj_weight)
+
+        if self.in_proj_bias is not None:
+            constant_(self.in_proj_bias, 0.0)
+            constant_(self.out_proj.bias, 0.0)
+        if self.bias_k is not None:
+            xavier_normal_(self.bias_k)
+        if self.bias_v is not None:
+            xavier_normal_(self.bias_v)
+
+    def __setstate__(self, state):
+        # Support loading old MultiheadAttention checkpoints generated by v1.1.0
+        if "_qkv_same_embed_dim" not in state:
+            state["_qkv_same_embed_dim"] = True
+
+        super(MultiheadAttention, self).__setstate__(state)
+
+    def forward(
+        self,
+        query: Tensor,
+        key: Tensor,
+        value: Tensor,
+        key_padding_mask: Optional[Tensor] = None,
+        need_weights: bool = True,
+        attn_mask: Optional[Tensor] = None,
+    ) -> Tuple[Tensor, Optional[Tensor]]:
+        r"""
+        Args:
+            query, key, value: map a query and a set of key-value pairs to an output.
+                See "Attention Is All You Need" for more details.
+            key_padding_mask: if provided, specified padding elements in the key will
+                be ignored by the attention. When given a binary mask and a value is True,
+                the corresponding value on the attention layer will be ignored. When given
+                a byte mask and a value is non-zero, the corresponding value on the attention
+                layer will be ignored
+            need_weights: output attn_output_weights.
+            attn_mask: 2D or 3D mask that prevents attention to certain positions. A 2D mask will be broadcasted for all
+                the batches while a 3D mask allows to specify a different mask for the entries of each batch.
+
+        Shapes for inputs:
+            - query: :math:`(L, N, E)` where L is the target sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+            - key: :math:`(S, N, E)`, where S is the source sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
+            - value: :math:`(S, N, E)` where S is the source sequence length, N is the batch size, E is
+              the embedding dimension. :math:`(N, S, E)` if ``batch_first`` is ``True``.
+            - key_padding_mask: :math:`(N, S)` where N is the batch size, S is the source sequence length.
+              If a ByteTensor is provided, the non-zero positions will be ignored while the position
+              with the zero positions will be unchanged. If a BoolTensor is provided, the positions with the
+              value of ``True`` will be ignored while the position with the value of ``False`` will be unchanged.
+            - attn_mask: if a 2D mask: :math:`(L, S)` where L is the target sequence length, S is the
+              source sequence length.
+
+              If a 3D mask: :math:`(N\cdot\text{num\_heads}, L, S)` where N is the batch size, L is the target sequence
+              length, S is the source sequence length. ``attn_mask`` ensure that position i is allowed to attend
+              the unmasked positions. If a ByteTensor is provided, the non-zero positions are not allowed to attend
+              while the zero positions will be unchanged. If a BoolTensor is provided, positions with ``True``
+              is not allowed to attend while ``False`` values will be unchanged. If a FloatTensor
+              is provided, it will be added to the attention weight.
+
+        Shapes for outputs:
+            - attn_output: :math:`(L, N, E)` where L is the target sequence length, N is the batch size,
+              E is the embedding dimension. :math:`(N, L, E)` if ``batch_first`` is ``True``.
+            - attn_output_weights: :math:`(N, L, S)` where N is the batch size,
+              L is the target sequence length, S is the source sequence length.
+        """
+        if self.batch_first:
+            query, key, value = [x.transpose(1, 0) for x in (query, key, value)]
+
+        if not self._qkv_same_embed_dim:
+            attn_output, attn_output_weights = multi_head_attention_forward(
+                query,
+                key,
+                value,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.bias_k,
+                self.bias_v,
+                self.add_zero_attn,
+                self.dropout,
+                self.out_proj.weight,
+                self.out_proj.bias,
+                training=self.training,
+                key_padding_mask=key_padding_mask,
+                need_weights=need_weights,
+                attn_mask=attn_mask,
+                use_separate_proj_weight=True,
+                q_proj_weight=self.q_proj_weight,
+                k_proj_weight=self.k_proj_weight,
+                v_proj_weight=self.v_proj_weight,
+            )
+        else:
+            attn_output, attn_output_weights = multi_head_attention_forward(
+                query,
+                key,
+                value,
+                self.embed_dim,
+                self.num_heads,
+                self.in_proj_weight,
+                self.in_proj_bias,
+                self.bias_k,
+                self.bias_v,
+                self.add_zero_attn,
+                self.dropout,
+                self.out_proj.weight,
+                self.out_proj.bias,
+                training=self.training,
+                key_padding_mask=key_padding_mask,
+                need_weights=need_weights,
+                attn_mask=attn_mask,
+            )
+        if self.batch_first:
+            return attn_output.transpose(1, 0), attn_output_weights
+        else:
+            return attn_output, attn_output_weights

--- a/tests/continual/multihead_attention/test_retroactive_mha.py
+++ b/tests/continual/multihead_attention/test_retroactive_mha.py
@@ -1,0 +1,234 @@
+import math
+
+import torch
+from ptflops import get_model_complexity_info
+from torch.nn.modules.activation import MultiheadAttention
+
+from continual.module import TensorPlaceholder
+from continual.multihead_attention.retroactive_mha import (
+    RetroactiveMultiheadAttention,
+    _scaled_dot_product_attention_default_state,
+    _scaled_dot_product_attention_step,
+)
+
+from .mha import _scaled_dot_product_attention
+
+torch.manual_seed(42)
+
+
+def test_multi_head_attention():
+    L = 10  # target sequence length
+    S = L  # source sequence length
+    E = 4  # embedding dimension
+    N = 5  # batch size
+    H = 2  # num heads
+    mha = MultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+    )
+    comha = RetroactiveMultiheadAttention.build_from(mha, sequence_len=L)
+
+    query = torch.randn((L, N, E))
+    key = torch.randn((S, N, E))
+    value = torch.randn((S, N, E))
+
+    # forward description
+    # query: (L,N,E) where L is the target sequence length, N is the batch size, E is the embedding dimension. (N,L,E) if batch_first is True.
+    # key: (S,N,E), where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    # value: (S,N,E) where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    attn_output, attn_weight = mha.forward(query, key, value)
+
+    # Forward is identical
+    attn_output2, attn_weight2 = comha.forward(query, key, value)
+    assert torch.equal(attn_output, attn_output2)
+    assert torch.equal(attn_weight, attn_weight2)
+
+    # Forward steps gives same output for full sequence
+    attn_output3 = comha.forward_steps(query, key, value)
+    assert torch.allclose(attn_output, attn_output3, atol=1e-6)
+
+    # Initialise, then use forward_step
+    comha.clean_state()
+    attn_output_dummy = comha.forward_steps(query[:-1], key[:-1], value[:-1])
+    assert isinstance(attn_output_dummy, TensorPlaceholder)
+    attn_output4 = comha.forward_step(query[-1], key[-1], value[-1])
+    assert torch.allclose(attn_output, attn_output4, atol=1e-6)
+
+    # Shift query, key and value by a time-step
+    query_step = torch.randn((N, E))
+    key_step = torch.randn((N, E))
+    value_step = torch.randn((N, E))
+
+    query2 = torch.cat((query[1:], query_step.unsqueeze(0)), dim=0)
+    key2 = torch.cat((key[1:], key_step.unsqueeze(0)), dim=0)
+    value2 = torch.cat((value[1:], value_step.unsqueeze(0)), dim=0)
+
+    assert torch.equal(query[1:], query2[:-1])
+    assert torch.equal(key[1:], key2[:-1])
+    assert torch.equal(value[1:], value2[:-1])
+
+    attn_output_next, _ = mha.forward(query2, key2, value2)
+
+    # Continual MHA should yield the same result by using query_step, key_step, and value_step
+    attn_output_next2 = comha.forward_step(query_step, key_step, value_step)
+    assert torch.allclose(attn_output_next, attn_output_next2, atol=1e-6)
+
+
+def test_scaled_dot_product_attention_step():
+    N = 10  # sequence length
+    E = 5  # embedding dimension
+    B = 2  # batch size
+    H = 1  # num heads
+
+    query1 = torch.randn((B, N, E))
+    key1 = torch.randn((B, N, E))
+    value1 = torch.randn((B, N, E))
+
+    # Manually compute first output
+    q = query1 / math.sqrt(E)
+    # (B, N, E) x (B, E, N) -> (B, N, N)
+    attn_exp = torch.exp(torch.bmm(q, key1.transpose(-2, -1)))
+    attn_sum = attn_exp.sum(dim=-1)  # over key dim
+
+    # (B, N, N) x (B, N, E) -> (B, N, E)
+    av = torch.bmm(attn_exp, value1)
+    output1 = av / attn_sum.unsqueeze(-1)
+
+    # Sanity check
+    target1, _ = _scaled_dot_product_attention(query1, key1, value1)
+    assert torch.allclose(target1, output1, atol=1e-7)
+
+    # == Ready for actual test! ==
+
+    # Shift query, key and value by a time-step
+    query_step = torch.randn((B, E))
+    key_step = torch.randn((B, E))
+    value_step = torch.randn((B, E))
+
+    query2 = torch.cat((query1[:, 1:], query_step.unsqueeze(1)), dim=1)
+    key2 = torch.cat((key1[:, 1:], key_step.unsqueeze(1)), dim=1)
+    value2 = torch.cat((value1[:, 1:], value_step.unsqueeze(1)), dim=1)
+
+    # Manually compute first output
+    q = query2 / math.sqrt(E)
+    # (B, N, E) x (B, E, N) -> (B, N, N)
+    # attn_exp2 = torch.exp(torch.bmm(q, key2.transpose(-2, -1)))
+    # av2 = torch.bmm(attn_exp2, value2)
+
+    target2, _ = _scaled_dot_product_attention(query2, key2, value2)
+
+    prev_state = (
+        # attn_sum[:, 1:],
+        attn_sum[:, 1:].unsqueeze(-1),
+        av[:, 1:],
+        # query1 / math.sqrt(E),
+        query1[:, 1:] / math.sqrt(E),
+        key1.transpose(-2, -1),
+        value1,
+        # 0,
+        # 0,
+        # 0,
+    )
+    output2, new_state = _scaled_dot_product_attention_step(
+        prev_state, query_step, key_step, value_step
+    )
+
+    for p, n in zip(prev_state, new_state):
+        assert p.shape == n.shape
+
+    assert torch.allclose(target2, output2, atol=1e-7)
+
+    # Now, let's try from zero-init
+    state = _scaled_dot_product_attention_default_state(B, N, E, H, dtype=torch.float)
+    for i in range(N):
+        output_step, state = _scaled_dot_product_attention_step(
+            state, query1[:, i], key1[:, i], value1[:, i]
+        )
+
+    assert torch.allclose(output_step, target1, atol=1e-7)
+
+    output_step, state = _scaled_dot_product_attention_step(
+        state, query_step, key_step, value_step
+    )
+    assert torch.allclose(output_step, target2, atol=1e-7)
+
+
+def test_flops():
+    L = 10  # target sequence length
+    E = 4  # embedding dimension
+    H = 2  # num heads
+
+    # Regular net
+    class Net(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mha = MultiheadAttention(
+                embed_dim=E,
+                num_heads=H,
+                dropout=0.0,
+                bias=True,
+                add_bias_kv=False,
+                add_zero_attn=False,
+                kdim=None,
+                vdim=None,
+                batch_first=True,
+                device=None,
+                dtype=None,
+            )
+
+        def forward(self, x):
+            y, _ = self.mha(x, x, x)
+            return y
+
+    net = Net()
+
+    flops, params = get_model_complexity_info(
+        net,
+        (L, E),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    # Continual net
+    co_net = RetroactiveMultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=True,
+        device=None,
+        dtype=None,
+        sequence_len=L,
+        forward_returns_attn_mask=False,
+    )
+
+    co_flops, co_params = get_model_complexity_info(
+        co_net,
+        (L, E),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    assert 1.1 * co_flops > flops and flops > 0.9 * co_flops  # Withing 10%
+    assert co_params == params
+
+    co_net.call_mode = "forward_step"
+    co_step_flops, co_step_params = get_model_complexity_info(
+        co_net,
+        (E,),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    assert 0.5 * flops > co_step_flops
+    assert co_step_params == params

--- a/tests/continual/multihead_attention/test_retroactive_mha.py
+++ b/tests/continual/multihead_attention/test_retroactive_mha.py
@@ -105,7 +105,7 @@ def test_scaled_dot_product_attention_step():
 
     # Sanity check
     target1, _ = _scaled_dot_product_attention(query1, key1, value1)
-    assert torch.allclose(target1, output1, atol=1e-7)
+    assert torch.allclose(target1, output1, atol=1e-6)
 
     # == Ready for actual test! ==
 
@@ -145,7 +145,7 @@ def test_scaled_dot_product_attention_step():
     for p, n in zip(prev_state, new_state):
         assert p.shape == n.shape
 
-    assert torch.allclose(target2, output2, atol=1e-7)
+    assert torch.allclose(target2, output2, atol=1e-6)
 
     # Now, let's try from zero-init
     state = _scaled_dot_product_attention_default_state(B, N, E, H, dtype=torch.float)
@@ -154,12 +154,12 @@ def test_scaled_dot_product_attention_step():
             state, query1[:, i], key1[:, i], value1[:, i]
         )
 
-    assert torch.allclose(output_step, target1, atol=1e-7)
+    assert torch.allclose(output_step, target1, atol=1e-6)
 
     output_step, state = _scaled_dot_product_attention_step(
         state, query_step, key_step, value_step
     )
-    assert torch.allclose(output_step, target2, atol=1e-7)
+    assert torch.allclose(output_step, target2, atol=1e-6)
 
 
 def test_flops():

--- a/tests/continual/multihead_attention/test_retroactive_mha.py
+++ b/tests/continual/multihead_attention/test_retroactive_mha.py
@@ -232,3 +232,9 @@ def test_flops():
 
     assert 0.5 * flops > co_step_flops
     assert co_step_params == params
+
+    # Including adds and exps in flops
+    co_step_flops_all = co_net.flops(
+        include_muls=True, include_adds=True, include_exps=True
+    )
+    assert co_step_flops_all > co_step_flops

--- a/tests/continual/multihead_attention/test_single_output_mha.py
+++ b/tests/continual/multihead_attention/test_single_output_mha.py
@@ -221,3 +221,9 @@ def test_flops():
     assert 0.1 * flops > co_step_flops
     assert co_step_flops > 0
     assert co_step_params == params
+
+    # Including adds and exps in flops
+    co_step_flops_all = co_net.flops(
+        include_muls=True, include_adds=True, include_exps=True
+    )
+    assert co_step_flops_all > co_step_flops

--- a/tests/continual/multihead_attention/test_single_output_mha.py
+++ b/tests/continual/multihead_attention/test_single_output_mha.py
@@ -1,0 +1,223 @@
+import torch
+from ptflops import get_model_complexity_info
+from torch.nn.modules.activation import MultiheadAttention
+
+from continual.module import TensorPlaceholder
+from continual.multihead_attention.single_output_mha import (
+    SingleOutputMultiheadAttention,
+)
+
+torch.manual_seed(42)
+
+
+def test_multi_head_attention_default_query_index():
+    L = 10  # target sequence length
+    S = L  # source sequence length
+    E = 4  # embedding dimension
+    N = 4  # batch size
+    H = 2  # num heads
+    mha = MultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+    )
+    query_index = -1
+    comha = SingleOutputMultiheadAttention.build_from(
+        mha, sequence_len=L, query_index=query_index
+    )
+
+    query = torch.randn((L, N, E))
+    key = torch.randn((S, N, E))
+    value = torch.randn((S, N, E))
+
+    # forward description
+    # query: (L,N,E) where L is the target sequence length, N is the batch size, E is the embedding dimension. (N,L,E) if batch_first is True.
+    # key: (S,N,E), where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    # value: (S,N,E) where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    attn_output, attn_weight = mha.forward(query, key, value)
+
+    # Forward is identical
+    attn_output2, attn_weight2 = comha.forward(query, key, value)
+    assert torch.equal(attn_output[query_index].unsqueeze(0), attn_output2)
+    assert torch.equal(attn_weight[:, query_index].unsqueeze(1), attn_weight2)
+
+    # Forward steps gives same output for full sequence
+    attn_output3 = comha.forward_steps(query, key, value)
+    assert torch.allclose(attn_output[query_index], attn_output3)
+
+    # Initialise, then use forward_step
+    comha.clean_state()
+    attn_output_dummy = comha.forward_steps(query[:-1], key[:-1], value[:-1])
+    assert isinstance(attn_output_dummy, TensorPlaceholder)
+    attn_output4 = comha.forward_step(query[-1], key[-1], value[-1])
+    assert torch.allclose(attn_output[query_index], attn_output4)
+
+    # Shift query, key and value by a time-step
+    query_step = torch.randn((N, E))
+    key_step = torch.randn((N, E))
+    value_step = torch.randn((N, E))
+
+    query2 = torch.cat((query[1:], query_step.unsqueeze(0)), dim=0)
+    key2 = torch.cat((key[1:], key_step.unsqueeze(0)), dim=0)
+    value2 = torch.cat((value[1:], value_step.unsqueeze(0)), dim=0)
+
+    assert torch.equal(query[1:], query2[:-1])
+    assert torch.equal(key[1:], key2[:-1])
+    assert torch.equal(value[1:], value2[:-1])
+
+    attn_output_next, _ = mha.forward(query2, key2, value2)
+
+    # Continual MHA should yield the same result by using query_step, key_step, and value_step
+    attn_output_next2 = comha.forward_step(query_step, key_step, value_step)
+    assert torch.allclose(attn_output_next[query_index], attn_output_next2)
+
+
+def test_multi_head_attention_nondefault_query_index():
+    L = 10  # target sequence length
+    S = L  # source sequence length
+    E = 4  # embedding dimension
+    N = 4  # batch size
+    H = 2  # num heads
+    mha = MultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=False,
+        device=None,
+        dtype=None,
+    )
+    query_index = 2
+    comha = SingleOutputMultiheadAttention.build_from(
+        mha, sequence_len=L, query_index=query_index
+    )
+
+    query = torch.randn((L, N, E))
+    key = torch.randn((S, N, E))
+    value = torch.randn((S, N, E))
+
+    # forward description
+    # query: (L,N,E) where L is the target sequence length, N is the batch size, E is the embedding dimension. (N,L,E) if batch_first is True.
+    # key: (S,N,E), where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    # value: (S,N,E) where S is the source sequence length, N is the batch size, E is the embedding dimension. (N,S,E) if batch_first is True.
+    attn_output, attn_weight = mha.forward(query, key, value)
+
+    # Forward is identical
+    attn_output2, attn_weight2 = comha.forward(query, key, value)
+    assert torch.equal(attn_output[query_index].unsqueeze(0), attn_output2)
+    assert torch.equal(attn_weight[:, query_index].unsqueeze(1), attn_weight2)
+
+    # Forward steps gives same output for full sequence
+    attn_output3 = comha.forward_steps(query, key, value)
+    assert torch.allclose(attn_output[query_index], attn_output3)
+
+    # Initialise, then use forward_step
+    comha.clean_state()
+    attn_output_dummy = comha.forward_steps(query[:-1], key[:-1], value[:-1])
+    assert isinstance(attn_output_dummy, TensorPlaceholder)
+    attn_output4 = comha.forward_step(query[-1], key[-1], value[-1])
+    assert torch.allclose(attn_output[query_index], attn_output4)
+
+    # Shift query, key and value by a time-step
+    query_step = torch.randn((N, E))
+    key_step = torch.randn((N, E))
+    value_step = torch.randn((N, E))
+
+    query2 = torch.cat((query[1:], query_step.unsqueeze(0)), dim=0)
+    key2 = torch.cat((key[1:], key_step.unsqueeze(0)), dim=0)
+    value2 = torch.cat((value[1:], value_step.unsqueeze(0)), dim=0)
+
+    assert torch.equal(query[1:], query2[:-1])
+    assert torch.equal(key[1:], key2[:-1])
+    assert torch.equal(value[1:], value2[:-1])
+
+    attn_output_next, _ = mha.forward(query2, key2, value2)
+
+    # Continual MHA should yield the same result by using query_step, key_step, and value_step
+    attn_output_next2 = comha.forward_step(query_step, key_step, value_step)
+    assert torch.allclose(attn_output_next[query_index], attn_output_next2)
+
+
+def test_flops():
+    L = 10  # target sequence length
+    E = 4  # embedding dimension
+    H = 2  # num heads
+
+    # Regular net
+    class Net(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.mha = MultiheadAttention(
+                embed_dim=E,
+                num_heads=H,
+                dropout=0.0,
+                bias=True,
+                add_bias_kv=False,
+                add_zero_attn=False,
+                kdim=None,
+                vdim=None,
+                batch_first=True,
+                device=None,
+                dtype=None,
+            )
+
+        def forward(self, x):
+            y, _ = self.mha(x, x, x)
+            return y
+
+    net = Net()
+
+    flops, params = get_model_complexity_info(
+        net,
+        (L, E),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    # Continual net
+    co_net = SingleOutputMultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=True,
+        device=None,
+        dtype=None,
+        sequence_len=L,
+        forward_returns_attn_mask=False,
+    )
+
+    co_flops, co_params = get_model_complexity_info(
+        co_net,
+        (L, E),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    assert 0.5 * flops > co_flops  # Within 10%
+    assert co_params == params
+
+    co_net.call_mode = "forward_step"
+    co_step_flops, co_step_params = get_model_complexity_info(
+        co_net,
+        (E,),
+        as_strings=False,  # input_constructor=input_constructor,
+    )
+
+    assert 0.1 * flops > co_step_flops
+    assert co_step_flops > 0
+    assert co_step_params == params

--- a/tests/continual/multihead_attention/test_stacked_mha.py
+++ b/tests/continual/multihead_attention/test_stacked_mha.py
@@ -1,0 +1,110 @@
+import torch
+from torch.nn.modules.activation import MultiheadAttention
+
+from continual.multihead_attention import (
+    RetroactiveMultiheadAttention,
+    SingleOutputMultiheadAttention,
+)
+
+
+def test_stacked_mha():
+    L = 10  # target sequence length
+    E = 4  # embedding dimension
+    N = 5  # batch size
+    H = 2  # num heads
+
+    # Regular net
+    r1 = MultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=True,
+        device=None,
+        dtype=None,
+    )
+    r2 = MultiheadAttention(
+        embed_dim=E,
+        num_heads=H,
+        dropout=0.0,
+        bias=True,
+        add_bias_kv=False,
+        add_zero_attn=False,
+        kdim=None,
+        vdim=None,
+        batch_first=True,
+        device=None,
+        dtype=None,
+    )
+
+    class Reg(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = r1
+            self.l2 = r2
+
+        def forward(self, x):
+            x, _ = self.l1(x, x, x)
+            x, _ = self.l2(x, x, x)
+            return x
+
+    reg = Reg()
+
+    # Continal net
+    c1 = RetroactiveMultiheadAttention.build_from(
+        r1, sequence_len=L, forward_returns_attn_mask=False
+    )
+    c2 = SingleOutputMultiheadAttention.build_from(
+        r2, sequence_len=L, query_index=-1, forward_returns_attn_mask=False
+    )
+
+    class Con(torch.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.l1 = c1
+            self.l2 = c2
+
+        def forward(self, x):
+            x = self.l1(x, x, x)
+            x = self.l2(x, x, x)
+            return x
+
+        def forward_step(self, x):
+            x = self.l1.forward_step(x, x, x)
+            if not isinstance(x, torch.Tensor):
+                return x
+            x = self.l2.forward(x, x, x)
+            return x
+
+        def forward_steps(self, x):
+            outs = []
+            for t in range(x.shape[1]):
+                o = self.forward_step(x[:, t])
+                if isinstance(o, torch.Tensor):
+                    outs.append(o)
+
+            if len(outs) > 0:
+                return torch.stack(outs, dim=1)
+            return o
+
+    con = Con()
+
+    # Test
+    x = torch.randn((N, L, E))
+
+    o_reg = reg.forward(x)  # Baseline
+
+    # Forward
+    o_con = con.forward(x)
+
+    assert torch.allclose(o_reg[:, -1], o_con[:, 0])
+
+    # Forward step
+    _ = con.forward_steps(x[:, :-1])  # initialise
+    o_con_step = con.forward_step(x[:, -1])
+
+    assert torch.allclose(o_reg[:, -1], o_con_step[:, 0])

--- a/tests/continual/test_positional_encoding.py
+++ b/tests/continual/test_positional_encoding.py
@@ -1,0 +1,42 @@
+import torch
+
+from continual.positional_encoding import RecyclingPositionalEncoding
+
+
+def test_RecyclingPositionalEncoding_learned():
+    B, C, T = 2, 3, 4
+
+    x = torch.zeros((B, C, T))
+
+    cpe = RecyclingPositionalEncoding(
+        embed_dim=C, num_embeds=T, forward_update_index_steps=0
+    )
+
+    o_forward = cpe.forward(x)
+
+    o_forward_steps = cpe.forward_steps(x[:, :, :-1])
+    assert torch.equal(o_forward[:, :, :-1], o_forward_steps)
+
+    o_forward_step = cpe.forward_step(x[:, :, -1])
+    assert torch.equal(o_forward[:, :, -1], o_forward_step)
+
+    cpe.clean_state()
+    assert torch.equal(cpe.forward(x), o_forward)
+
+
+def test_RecyclingPositionalEncoding_static():
+    B, C, T = 2, 13, 4
+
+    x = torch.zeros((B, C, T))
+
+    cpe = RecyclingPositionalEncoding(
+        embed_dim=C, num_embeds=T, forward_update_index_steps=0, learned=False
+    )
+
+    o_forward = cpe.forward(x)
+
+    o_forward_steps = cpe.forward_steps(x[:, :, :-1])
+    assert torch.equal(o_forward[:, :, :-1], o_forward_steps)
+
+    o_forward_step = cpe.forward_step(x[:, :, -1])
+    assert torch.equal(o_forward[:, :, -1], o_forward_step)

--- a/tests/continual/test_transformer.py
+++ b/tests/continual/test_transformer.py
@@ -54,3 +54,54 @@ def test_trans_enc_b1():
     )
 
     assert step_flops <= flops / T
+
+
+def test_trans_enc_b2():
+    T = 10  # temporal sequence length
+    E = 4  # embedding dimension
+    N = 1  # batch size
+    H = 2  # num heads
+
+    encoder_layer = nn.TransformerEncoderLayer(
+        d_model=E, nhead=H, dim_feedforward=E * 2, dropout=0.0, batch_first=True
+    )
+    regenc = nn.TransformerEncoder(
+        encoder_layer,
+        num_layers=2,
+        # norm=nn.LayerNorm(E),
+    )
+
+    enc = co.TransformerEncoder.build_from(regenc, sequence_len=T)
+
+    # NB: regular and continual transformers expect different input formats
+    query = torch.randn((N, E, T))
+    query_reg_format = query.permute(0, 2, 1)  # N, T, E
+
+    # Baseline
+    oreg = regenc.forward(query_reg_format)
+    o = enc.forward(query)
+
+    assert torch.allclose(oreg.permute(0, 2, 1)[:, :, -1], o.squeeze(-1))
+
+    # Forward step
+    o_step = enc.forward_steps(query[:, :, :-1])  # init
+
+    o_step = enc.forward_step(query[:, :, -1])
+
+    assert torch.allclose(o[:, :, -1], o_step)
+
+    # FLOPs
+    flops, _ = get_model_complexity_info(
+        enc,
+        (E, T),
+        as_strings=False,
+    )
+
+    enc.call_mode = "forward_step"
+    step_flops, _ = get_model_complexity_info(
+        enc,
+        (E,),
+        as_strings=False,
+    )
+
+    assert step_flops <= flops

--- a/tests/continual/test_transformer.py
+++ b/tests/continual/test_transformer.py
@@ -86,9 +86,13 @@ def test_trans_enc_b2():
     # Forward step
     o_step = enc.forward_steps(query[:, :, :-1])  # init
 
-    o_step = enc.forward_step(query[:, :, -1])
+    o_step = enc.forward_step(query[:, :, -1], update_state=False)
 
     assert torch.allclose(o[:, :, -1], o_step)
+
+    # Same result with forward_steps
+    o_step2 = enc.forward_steps(query[:, :, -1].unsqueeze(-1))
+    assert torch.allclose(o_step, o_step2.squeeze(-1))
 
     # FLOPs
     flops, _ = get_model_complexity_info(

--- a/tests/continual/test_transformer.py
+++ b/tests/continual/test_transformer.py
@@ -1,0 +1,56 @@
+import torch
+from ptflops import get_model_complexity_info
+from torch import nn
+
+import continual as co
+
+
+def test_trans_enc_b1():
+    T = 10  # temporal sequence length
+    E = 4  # embedding dimension
+    N = 1  # batch size
+    H = 2  # num heads
+
+    encoder_layer = nn.TransformerEncoderLayer(
+        d_model=E, nhead=H, dim_feedforward=E * 2, dropout=0.0, batch_first=True
+    )
+    regenc = nn.TransformerEncoder(
+        encoder_layer,
+        num_layers=1,
+        norm=nn.LayerNorm(E),
+    )
+
+    enc = co.TransformerEncoder.build_from(regenc, sequence_len=T)
+
+    # NB: regular and continual transformers expect different input formats
+    query = torch.randn((N, E, T))
+    query_reg_format = query.permute(0, 2, 1)  # N, T, E
+
+    # Baseline
+    oreg = regenc.forward(query_reg_format)
+    o = enc.forward(query)
+
+    assert torch.allclose(oreg.permute(0, 2, 1), o)
+
+    # Forward step
+    o_step = enc.forward_steps(query[:, :, :-1])  # init
+
+    o_step = enc.forward_step(query[:, :, -1])
+
+    assert torch.allclose(o[:, :, -1], o_step)
+
+    # FLOPs
+    flops, _ = get_model_complexity_info(
+        enc,
+        (E, T),
+        as_strings=False,
+    )
+
+    enc.call_mode = "forward_step"
+    step_flops, _ = get_model_complexity_info(
+        enc,
+        (E,),
+        as_strings=False,
+    )
+
+    assert step_flops <= flops / T


### PR DESCRIPTION
### Added
- Citations for Continual Inference lib paper.
- Docs.
- Automatic conversion for RNN modules.
- Continual Transformer modules, including:
    - `RecyclingPositionalEncoding`
    - `RetroactiveMultiheadAttention`
    - `SingleOutputMultiheadAttention`
    - `SingleOutputTransformerEncoderLayer`
    - `RetroactiveTransformerEncoderLayer`
    - `TransformerEncoderLayerFactory`
    - `TransformerEncoder`
