### PR TITLE
Fix strings option in TransformerEncoderLayerFactory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ## Unpublished
 
+## [1.2.2] - 2023-05-24
+
+### Removed
+- Option to use strings to specify transformer activation.
+
+
 ## [1.2.1] - 2023-03-24
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ From v1.0.0 and on, the project will adherence strictly to Semantic Versioning.
 
 ## [1.2.2] - 2023-05-24
 
-### Removed
+### Fixed
 - Option to use strings to specify transformer activation.
 
 

--- a/continual/__about__.py
+++ b/continual/__about__.py
@@ -1,6 +1,6 @@
 import time
 
-__version__ = "1.2.1"
+__version__ = "1.2.2"
 __author__ = "Lukas Hedegaard"
 __author_email__ = "lukasxhedegaard@gmail.com"
 __license__ = "Apache-2.0"

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -185,8 +185,8 @@ def SingleOutputTransformerEncoderLayer(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer, can be a string
-            ("relu" or "gelu") or a unary callable. Default: relu.
+        activation: the activation function of the intermediate layer. Should be callable
+            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.
@@ -324,8 +324,8 @@ def RetroactiveTransformerEncoderLayer(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer, can be a string
-            ("relu" or "gelu") or a unary callable. Default: relu.
+        activation: the activation function of the intermediate layer. Should be callable
+            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.
@@ -451,8 +451,8 @@ def TransformerEncoderLayerFactory(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer, can be a string
-            ("relu" or "gelu") or a unary callable. Default: relu.
+        activation: the activation function of the intermediate layer. Should be callable
+            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -428,7 +428,7 @@ def TransformerEncoderLayerFactory(
     nhead: int,
     dim_feedforward: int = 2048,
     dropout: float = 0.1,
-    activation: Union[nn.Module, Callable[[Tensor], Tensor]] = nn.functional.relu,
+    activation: Union[nn.Module, Callable[[Tensor], Tensor], str] = nn.functional.relu,
     layer_norm_eps: float = 1e-5,
     # batch_first: bool = True,
     # norm_first: bool = False,
@@ -469,6 +469,11 @@ def TransformerEncoderLayerFactory(
         src = torch.rand(10, 512, 32)
         out = transformer_encoder(src)
     """
+    if activation in {"relu", "gelu"}:
+        activation = {
+            "relu": nn.functional.relu,
+            "gelu": nn.functional.relu,
+        }[activation]
 
     def TransformerEncoderLayer(mha_type: MhaType):
         factory_fn = {

--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -185,8 +185,8 @@ def SingleOutputTransformerEncoderLayer(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer. Should be callable
-            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
+        activation: the activation function of the intermediate layer, can be a string
+            ("relu" or "gelu") or a unary callable. Default: relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.
@@ -324,8 +324,8 @@ def RetroactiveTransformerEncoderLayer(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer. Should be callable
-            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
+        activation: the activation function of the intermediate layer, can be a string
+            ("relu" or "gelu") or a unary callable. Default: relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.
@@ -451,8 +451,8 @@ def TransformerEncoderLayerFactory(
         nhead: the number of heads in the multiheadattention models (required).
         dim_feedforward: the dimension of the feedforward network model (default=2048).
         dropout: the dropout value (default=0.1).
-        activation: the activation function of the intermediate layer. Should be callable
-            (e.g., `nn.functional.relu` or `nn.ReLU()`). Default: nn.functional.relu.
+        activation: the activation function of the intermediate layer, can be a string
+            ("relu" or "gelu") or a unary callable. Default: relu.
         layer_norm_eps: the eps value in layer normalization components (default=1e-5).
         device: torch device to initialize layer on. Defaults to None.
         dtype: datatype of layer parameters. Defaults to None.

--- a/tests/continual/test_onnx.py
+++ b/tests/continual/test_onnx.py
@@ -402,6 +402,7 @@ def test_trans_enc_b1(tmp_path):
             dim_feedforward=E * 2,
             dropout=0.0,
             sequence_len=T,
+            activation="relu",
         ),
         num_layers=1,
     )


### PR DESCRIPTION
### Fixed
- Option to use strings to specify transformer activation.