### PR TITLE
Fix multilayer transformers when num_layers>=3

### DIFF
--- a/continual/transformer.py
+++ b/continual/transformer.py
@@ -550,7 +550,7 @@ class TransformerEncoder(Sequential):
             layers.append(encoder_layer(MhaType.SINGLE_OUTPUT))
         else:
             layers.append(encoder_layer(MhaType.RETROACTIVE))
-            for _ in range(2, num_layers - 1):
+            for _ in range(1, num_layers - 1):
                 layers.append(
                     RetroactiveLambda(encoder_layer(MhaType.REGULAR), takes_time=True)
                 )


### PR DESCRIPTION
The TransformerEncoder class returns one transformer layer less than it should when num_layers>=3